### PR TITLE
13/fix-pages-data-match

### DIFF
--- a/src/app/api/overview/deliveries/detail/route.ts
+++ b/src/app/api/overview/deliveries/detail/route.ts
@@ -70,6 +70,13 @@ export async function GET(request: NextRequest) {
                   ? Prisma.sql`d."householdId18" = ${householdId18Param}`
                   : Prisma.empty;
 
+        const justEatsHouseholdPredicate =
+            scope.kind === 'partner'
+                ? Prisma.sql`t."householdId" = ${scope.partnerHouseholdId18}`
+                : householdId18Param
+                  ? Prisma.sql`t."householdId" = ${householdId18Param}`
+                  : Prisma.empty;
+
         // Use pantry visit date (d.date) to match overview delivery day grouping.
         const foodRows = await prisma.$queryRaw<FoodRow[]>`
             SELECT
@@ -81,7 +88,18 @@ export async function GET(request: NextRequest) {
             WHERE DATE_TRUNC('day', d."date") = DATE_TRUNC('day', ${date})
               AND ${destinationPredicate}
             GROUP BY p."pantryProductName"
-            ORDER BY SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) DESC
+
+            UNION ALL 
+
+            SELECT
+                COALESCE(t."productPackageName", 'Unknown') AS "productName",
+                COUNT(*) * 25 AS "totalWeightLbs"
+            FROM "JustEatsBoxes" t
+            WHERE DATE_TRUNC('day', t."pantryVisitDateTime") = DATE_TRUNC('day', ${date})
+              AND ${justEatsHouseholdPredicate}
+            GROUP BY t."productPackageName"
+
+            ORDER BY "totalWeightLbs" DESC
         `;
 
         const totalPounds = foodRows.reduce((sum, r) => sum + Number(r.totalWeightLbs ?? 0), 0);

--- a/src/app/api/overview/deliveries/route.ts
+++ b/src/app/api/overview/deliveries/route.ts
@@ -114,7 +114,21 @@ export async function GET(request: NextRequest) {
             WHERE d."date" >= ${range.start}
               AND d."date" <= ${range.end}
             GROUP BY DATE_TRUNC('day', d."date"), d."householdId18", COALESCE(pt."organizationName", d."householdName")
-            ORDER BY DATE_TRUNC('day', d."date") DESC
+
+            UNION ALL
+
+            SELECT
+                TO_CHAR(DATE_TRUNC('day', t."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+                COALESCE(pt."organizationName", t."householdName") AS "destination",
+                t."householdId" AS "householdId18",
+                COUNT(*) * 25 as "totalPounds"
+            FROM "JustEatsBoxes" t
+            LEFT JOIN "Partner" pt ON pt."householdId18" = t."householdId"
+            WHERE t."pantryVisitDateTime" >= ${range.start}
+              AND t."pantryVisitDateTime" <= ${range.end}
+            GROUP BY DATE_TRUNC('day', t."pantryVisitDateTime"), t."householdId", COALESCE(pt."organizationName", t."householdName")
+            
+            ORDER BY "day" DESC
             LIMIT 10
         `;
 

--- a/src/app/api/overview/pounds-by-month/route.ts
+++ b/src/app/api/overview/pounds-by-month/route.ts
@@ -104,8 +104,52 @@ export async function GET(request: NextRequest) {
                 ORDER BY DATE_TRUNC('day', d."date") ASC
             `;
 
+        const justEatsDailyRows = partnerHouseholdId18
+            ? await prisma.$queryRaw<DailyRow[]>`
+                SELECT
+                    TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+                    COUNT(*) * 25 AS "pounds"
+                FROM "JustEatsBoxes" d
+                WHERE d."householdId" = ${partnerHouseholdId18}
+                  AND d."pantryVisitDateTime" >= ${range.start}
+                  AND d."pantryVisitDateTime" <= ${range.end}
+                GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
+                ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
+            `
+            : await prisma.$queryRaw<DailyRow[]>`
+                SELECT
+                    TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+                    COUNT(*) * 25 AS "pounds"
+                FROM "JustEatsBoxes" d
+                WHERE d."pantryVisitDateTime" >= ${range.start}
+                  AND d."pantryVisitDateTime" <= ${range.end}
+                GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
+                ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
+            `;
+
         const buckets: Record<string, number> = {};
+
+        // add data from AllPackagesByItem to an array
         for (const row of dailyRows) {
+            const [yearStr, monthStr, dayStr] = row.day.split('-');
+            const y = Number.parseInt(yearStr ?? '', 10);
+            const m = Number.parseInt(monthStr ?? '', 10);
+            const day = Number.parseInt(dayStr ?? '', 10);
+            if (Number.isNaN(y) || Number.isNaN(m) || Number.isNaN(day)) continue;
+            const weight = Number(row.pounds ?? 0);
+            let key: string;
+            if (aggregateByYear) {
+                key = String(y);
+            } else if (aggregateByDay) {
+                key = `${String(m).padStart(2, '0')}/${String(day).padStart(2, '0')}`;
+            } else {
+                key = `${MONTH_NAMES[m - 1]} ${y}`;
+            }
+            buckets[key] = (buckets[key] ?? 0) + weight;
+        }
+
+        // add data from JustEatsBoxes to an existing array
+        for (const row of justEatsDailyRows) {
             const [yearStr, monthStr, dayStr] = row.day.split('-');
             const y = Number.parseInt(yearStr ?? '', 10);
             const m = Number.parseInt(monthStr ?? '', 10);


### PR DESCRIPTION
When pressing _month to date_ filter option, the most recent deliveries from the **JustEatsBoxes** are now being displayed in the overview stats page, matching that of the distribution page.

Refer below for the before vs. after!

<img width="553" height="550" alt="Screenshot 2026-04-18 at 2 45 20 PM" src="https://github.com/user-attachments/assets/d2722cf1-e381-4c07-bf8e-36b8a7e50a5e" />
<img width="555" height="584" alt="Screenshot 2026-04-18 at 2 44 42 PM" src="https://github.com/user-attachments/assets/b2846f4a-a1f7-4005-a10c-023925159fbc" />
