### PR TITLE
Destination-only partners

### DIFF
--- a/lib/destinationNameFilter.ts
+++ b/lib/destinationNameFilter.ts
@@ -1,0 +1,25 @@
+export function normalizeDestinationName(value: string): string {
+    return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function uniqueNormalizedNames(values: string[]): string[] {
+    const byNormalized = new Map<string, string>();
+    for (const value of values) {
+        const trimmed = value.trim();
+        if (!trimmed) continue;
+        const normalized = normalizeDestinationName(trimmed);
+        if (!normalized) continue;
+        if (!byNormalized.has(normalized)) {
+            byNormalized.set(normalized, trimmed);
+        }
+    }
+    return [...byNormalized.values()];
+}
+
+export function readDestinationNames(searchParams: URLSearchParams): string[] {
+    const raw = [
+        ...searchParams.getAll('destinationName'),
+        ...searchParams.getAll('destinationNames').flatMap(value => value.split(',')),
+    ];
+    return uniqueNormalizedNames(raw);
+}

--- a/lib/distributionDeliveries.ts
+++ b/lib/distributionDeliveries.ts
@@ -90,7 +90,10 @@ export async function queryDistributionDeliveries(
         SELECT * FROM (
             SELECT
                 d."date" AS "date",
-                COALESCE(pt."organizationName", d."householdName") AS "organizationName",
+                COALESCE(
+                    NULLIF(BTRIM(d."householdName"), ''),
+                    NULLIF(BTRIM(pt."organizationName"), '')
+                ) AS "organizationName",
                 d."householdId18" AS "householdId18",
                 p."pantryProductName" AS "productName",
                 COALESCE(p."distributionAmount", 1) AS "distributionAmount",
@@ -133,6 +136,7 @@ export async function queryDistributionDeliveries(
               AND t."date" <= ${params.end}
               AND ${distributionInventoryTypeCondition}
               AND ${orphanInventoryCondition}
+              AND TRIM(COALESCE(t."destination", '')) <> ''
               ${orphanOrg}
               ${orphanSearchClause}
         ) AS combined_bulk
@@ -176,12 +180,15 @@ export async function queryJustEatsDistributionDeliveries(
     const rows = await db.$queryRaw<JustEatsRowDb[]>`
         SELECT
             j."pantryVisitDateTime" AS "date",
-            COALESCE(pt."organizationName", j."householdName") AS "organizationName",
+            COALESCE(
+                NULLIF(BTRIM(j."householdName"), ''),
+                NULLIF(BTRIM(pt."organizationName"), '')
+            ) AS "organizationName",
             j."householdId" AS "householdId18",
             NULLIF(BTRIM(j."productPackageName"), '') AS "productName",
-            1 AS "distributionAmount",
+            COALESCE(j."numberDistributed", 1) AS "distributionAmount",
             25::double precision AS "unitWeightLbs",
-            25::double precision AS "weightLbs",
+            (COALESCE(j."numberDistributed", 1) * 25)::double precision AS "weightLbs",
             'Just Eats' AS "inventoryType",
             NULL::text AS "productType",
             NULL::boolean AS "minimallyProcessedFood",
@@ -195,6 +202,23 @@ export async function queryJustEatsDistributionDeliveries(
           AND j."pantryVisitDateTime" <= ${params.end}
           ${destClause}
           ${searchClause}
+          AND NULLIF(BTRIM(j."householdName"), '') IS NOT NULL
+          AND EXISTS (
+              SELECT 1
+              FROM (
+                  SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                  FROM "AllProductPackageDestinations" d2
+                  WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                  UNION
+
+                  SELECT LOWER(TRIM(t2."destination")) AS org_name
+                  FROM "AllInventoryTransactions" t2
+                  WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                    AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+              ) valid_orgs
+              WHERE valid_orgs.org_name = LOWER(TRIM(j."householdName"))
+          )
         ORDER BY j."pantryVisitDateTime" DESC
     `;
     return rows.map(r => ({ ...r, program: 'just_eats' as const }));

--- a/lib/distributionDeliveries.ts
+++ b/lib/distributionDeliveries.ts
@@ -1,8 +1,13 @@
 import { Prisma } from '@prisma/client';
 import type { PrismaClient } from '@prisma/client';
 import type { OverviewScope } from '~/lib/overviewAccess';
+import {
+    distributionInventoryTypeCondition,
+    inventoryTxPoundsSql,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 
-/** Org name filter for distribution SQL (ILIKE). Undefined = all orgs (admin, no destination). */
+/** Org name filter for distribution SQL (ILIKE pattern or exact normalized match via caller). */
 export function distributionOrgScopeFromOverview(scope: OverviewScope): string | undefined {
     if (scope.kind === 'admin') return scope.destination;
     if (scope.kind === 'partner') return scope.destination;
@@ -12,7 +17,7 @@ export function distributionOrgScopeFromOverview(scope: OverviewScope): string |
 export type DistributionDeliveryRow = {
     date: Date;
     organizationName: string;
-    householdId18: string;
+    householdId18: string | null;
     productName: string | null;
     distributionAmount: number;
     unitWeightLbs: number | null;
@@ -31,6 +36,21 @@ type BulkRowDb = Omit<DistributionDeliveryRow, 'program' | 'lineId'>;
 
 type Db = Pick<PrismaClient, '$queryRaw'>;
 
+function orphanOrgClause(params: {
+    partnerHouseholdId18?: string;
+    orgFilter?: string;
+    destinationLabel?: string;
+}): Prisma.Sql {
+    const label = params.destinationLabel?.trim();
+    if (params.partnerHouseholdId18 && label) {
+        return Prisma.sql` AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${label})) `;
+    }
+    if (params.orgFilter?.trim()) {
+        return Prisma.sql` AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${params.orgFilter.trim()})) `;
+    }
+    return Prisma.empty;
+}
+
 export async function queryDistributionDeliveries(
     db: Db,
     params: {
@@ -38,8 +58,9 @@ export async function queryDistributionDeliveries(
         end: Date;
         search: string;
         orgFilter: string | undefined;
-        /** When set (partner scope), filter by destination household id — matches overview stats. */
         partnerHouseholdId18?: string | undefined;
+        /** Matches orphan `destination` when scoped by Salesforce household id. */
+        destinationLabel?: string | undefined;
     }
 ): Promise<DistributionDeliveryRow[]> {
     const search = params.search.trim().toLowerCase();
@@ -52,37 +73,70 @@ export async function queryDistributionDeliveries(
         params.partnerHouseholdId18 != null && params.partnerHouseholdId18 !== ''
             ? Prisma.sql` AND d."householdId18" = ${params.partnerHouseholdId18} `
             : params.orgFilter
-              ? Prisma.sql` AND d."householdName" ILIKE ${params.orgFilter} `
+              ? Prisma.sql` AND LOWER(TRIM(COALESCE(d."householdName", ''))) = LOWER(TRIM(${params.orgFilter.trim()})) `
               : Prisma.empty;
 
-    // Do not require t.destination: source exports often leave it blank; org is d.householdName via join.
-    // Use d.date (pantry visit date/time) for the delivery date shown in UI.
+    const orphanSearchClause = search
+        ? Prisma.sql`AND COALESCE(t."pantryProductName", '') ILIKE ${searchFilter}`
+        : Prisma.empty;
+
+    const orphanOrg = orphanOrgClause({
+        partnerHouseholdId18: params.partnerHouseholdId18,
+        orgFilter: params.orgFilter,
+        destinationLabel: params.destinationLabel,
+    });
+
     const rows = await db.$queryRaw<BulkRowDb[]>`
-        SELECT
-            d."date" AS "date",
-            COALESCE(pt."organizationName", d."householdName") AS "organizationName",
-            d."householdId18" AS "householdId18",
-            p."pantryProductName" AS "productName",
-            COALESCE(p."distributionAmount", 1) AS "distributionAmount",
-            p."pantryProductWeightLbs" AS "unitWeightLbs",
-            (COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "weightLbs",
-            t."inventoryType" AS "inventoryType",
-            t."productType" AS "productType",
-            t."minimallyProcessedFood" AS "minimallyProcessedFood",
-            p."lotFoodRescueProgram" AS "foodRescueProgram",
-            t."source" AS "source"
-        FROM "AllInventoryTransactions" t
-        INNER JOIN "AllPackagesByItem" p
-            ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
-        INNER JOIN "AllProductPackageDestinations" d
-            ON d."productPackageId18" = p."productPackageId18"
-        LEFT JOIN "Partner" pt
-            ON pt."householdId18" = d."householdId18"
-        WHERE d."date" >= ${params.start}
-          AND d."date" <= ${params.end}
-          ${destClause}
-          ${searchClause}
-        ORDER BY d."date" DESC
+        SELECT * FROM (
+            SELECT
+                d."date" AS "date",
+                COALESCE(pt."organizationName", d."householdName") AS "organizationName",
+                d."householdId18" AS "householdId18",
+                p."pantryProductName" AS "productName",
+                COALESCE(p."distributionAmount", 1) AS "distributionAmount",
+                p."pantryProductWeightLbs" AS "unitWeightLbs",
+                (COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "weightLbs",
+                t."inventoryType" AS "inventoryType",
+                t."productType" AS "productType",
+                t."minimallyProcessedFood" AS "minimallyProcessedFood",
+                p."lotFoodRescueProgram" AS "foodRescueProgram",
+                t."source" AS "source"
+            FROM "AllInventoryTransactions" t
+            INNER JOIN "AllPackagesByItem" p
+                ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+            INNER JOIN "AllProductPackageDestinations" d
+                ON d."productPackageId18" = p."productPackageId18"
+            LEFT JOIN "Partner" pt
+                ON pt."householdId18" = d."householdId18"
+            WHERE d."date" >= ${params.start}
+              AND d."date" <= ${params.end}
+              ${destClause}
+              ${searchClause}
+
+            UNION ALL
+
+            SELECT
+                t."date" AS "date",
+                TRIM(t."destination") AS "organizationName",
+                NULL::text AS "householdId18",
+                t."pantryProductName" AS "productName",
+                1 AS "distributionAmount",
+                NULL::double precision AS "unitWeightLbs",
+                ${inventoryTxPoundsSql()} AS "weightLbs",
+                t."inventoryType" AS "inventoryType",
+                t."productType" AS "productType",
+                t."minimallyProcessedFood" AS "minimallyProcessedFood",
+                NULL::text AS "foodRescueProgram",
+                t."source" AS "source"
+            FROM "AllInventoryTransactions" t
+            WHERE t."date" >= ${params.start}
+              AND t."date" <= ${params.end}
+              AND ${distributionInventoryTypeCondition}
+              AND ${orphanInventoryCondition}
+              ${orphanOrg}
+              ${orphanSearchClause}
+        ) AS combined_bulk
+        ORDER BY combined_bulk."date" DESC
     `;
     return rows.map(r => ({
         ...r,
@@ -116,7 +170,7 @@ export async function queryJustEatsDistributionDeliveries(
         params.partnerHouseholdId18 != null && params.partnerHouseholdId18 !== ''
             ? Prisma.sql` AND j."householdId" = ${params.partnerHouseholdId18} `
             : params.orgFilter
-              ? Prisma.sql` AND j."householdName" ILIKE ${params.orgFilter} `
+              ? Prisma.sql` AND LOWER(TRIM(COALESCE(j."householdName", ''))) = LOWER(TRIM(${params.orgFilter.trim()})) `
               : Prisma.empty;
 
     const rows = await db.$queryRaw<JustEatsRowDb[]>`

--- a/lib/inventoryDistributionSql.ts
+++ b/lib/inventoryDistributionSql.ts
@@ -1,0 +1,24 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Rows in AllInventoryTransactions that never chain through packages into
+ * AllProductPackageDestinations — counted separately so we do not double-count joined rows.
+ */
+export const orphanInventoryCondition = Prisma.sql`
+  NOT EXISTS (
+    SELECT 1 FROM "AllPackagesByItem" p
+    INNER JOIN "AllProductPackageDestinations" d
+      ON d."productPackageId18" = p."productPackageId18"
+    WHERE p."productInventoryRecordId18" = t."productInventoryRecordId18"
+  )
+`;
+
+/** Only distribution rows from inventory exports (exclude intake and other flows). */
+export const distributionInventoryTypeCondition = Prisma.sql`
+  LOWER(TRIM(COALESCE(t."inventoryType", ''))) = 'distribution'
+`;
+
+/** Pounds for an inventory transaction line (prefers Weight when present). */
+export function inventoryTxPoundsSql(): Prisma.Sql {
+    return Prisma.sql`COALESCE(NULLIF(t."weightLbs", 0), NULLIF(t."amount"::double precision, 0), 0)`;
+}

--- a/lib/overviewAccess.ts
+++ b/lib/overviewAccess.ts
@@ -67,11 +67,46 @@ export async function getOverviewScope(
     };
 }
 
+/** Synthetic Partner.householdId18 when no Salesforce id was provided at signup. */
+export const PENDING_PARTNER_HOUSEHOLD_PREFIX = 'pending-' as const;
+
 /** Partner account: Salesforce household id for `JustEatsBoxes.householdId` joins. */
 export function scopeToPartnerHouseholdId18(scope: OverviewScope): string | undefined {
     if (scope.kind === 'admin') return scope.destinationHouseholdId18;
     if (scope.kind === 'partner') return scope.partnerHouseholdId18;
     return undefined;
+}
+
+/**
+ * When true, bulk/rescue metrics come from destination/org name (inventory `destination`,
+ * destination tables’ household names), not Salesforce household id joins.
+ */
+export function partnerUsesDestinationNameOnly(scope: OverviewScope): boolean {
+    if (scope.kind === 'partner') {
+        return scope.partnerHouseholdId18.startsWith(PENDING_PARTNER_HOUSEHOLD_PREFIX);
+    }
+    if (scope.kind === 'admin') {
+        return Boolean(scope.destination && !scope.destinationHouseholdId18);
+    }
+    return false;
+}
+
+/**
+ * Exact case-insensitive match for filtering by partner or destination display name.
+ */
+export function scopeOrganizationNameFilter(scope: OverviewScope): string | undefined {
+    if (!partnerUsesDestinationNameOnly(scope)) return undefined;
+    if (scope.kind === 'partner') return scope.destination.trim();
+    if (scope.kind === 'admin' && scope.destination) return scope.destination.trim();
+    return undefined;
+}
+
+/**
+ * True scoped household id for JE / joined bulk; omit when using destination-name-only scope.
+ */
+export function scopeEffectiveHouseholdId18(scope: OverviewScope): string | undefined {
+    if (partnerUsesDestinationNameOnly(scope)) return undefined;
+    return scopeToPartnerHouseholdId18(scope);
 }
 
 export function overviewScopeErrorResponse(scope: OverviewScope): NextResponse | null {

--- a/prisma/migrations/20260427163000_add_partner_name_aliases/migration.sql
+++ b/prisma/migrations/20260427163000_add_partner_name_aliases/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "PartnerNameAlias" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "clerkOrganizationId" TEXT NOT NULL,
+    "aliasName" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "PartnerNameAlias_clerkOrganizationId_aliasName_key"
+    ON "PartnerNameAlias"("clerkOrganizationId", "aliasName");
+
+CREATE INDEX IF NOT EXISTS "PartnerNameAlias_aliasName_idx"
+    ON "PartnerNameAlias"("aliasName");

--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -71,7 +71,7 @@ const AdminConsolePage: React.FC = () => {
     };
 
     //Handle creating new organization
-    const handleAddPartner = async (data: { name: string; householdId18: string }) => {
+    const handleAddPartner = async (data: { name: string; householdId18?: string }) => {
         try {
             const response = await fetch('/api/admin/organizations', {
                 method: 'POST',

--- a/src/app/(dashboard)/distribution/page.tsx
+++ b/src/app/(dashboard)/distribution/page.tsx
@@ -22,7 +22,7 @@ import {
 } from '~/lib/chartCompositionColors';
 
 interface DeliveryRecord {
-    householdId18: string;
+    householdId18: string | null;
     date: string;
     organizationName: string;
     productName: string | null;
@@ -131,8 +131,11 @@ function DistributionContent() {
     // Read org from URL on mount (for deep-linking)
     useEffect(() => {
         const householdId18 = searchParams.get('householdId18')?.trim();
+        const destination = searchParams.get('destination')?.trim();
         if (householdId18) {
             setSelectedOrg({ name: 'Selected organization', householdId18 });
+        } else if (destination) {
+            setSelectedOrg({ name: destination, householdId18: null });
         }
     }, [searchParams, setSelectedOrg]);
 
@@ -156,24 +159,40 @@ function DistributionContent() {
 
     // Resolve org name from partner list once loaded
     useEffect(() => {
-        if (
-            !selectedOrg ||
-            selectedOrg.name !== 'Selected organization' ||
-            partnerOrganizations.length === 0
-        )
+        if (!selectedOrg || partnerOrganizations.length === 0) return;
+        if (selectedOrg.name === 'Selected organization' && selectedOrg.householdId18) {
+            const match = partnerOrganizations.find(
+                p => p.householdId18 === selectedOrg.householdId18
+            );
+            if (match) setSelectedOrg({ name: match.name, householdId18: match.householdId18 });
             return;
-        const match = partnerOrganizations.find(p => p.householdId18 === selectedOrg.householdId18);
-        if (match) setSelectedOrg({ name: match.name, householdId18: match.householdId18 });
+        }
+        if (
+            selectedOrg.name &&
+            selectedOrg.name !== 'Selected organization' &&
+            !selectedOrg.householdId18
+        ) {
+            const match = partnerOrganizations.find(
+                p =>
+                    p.name.toLowerCase() === selectedOrg.name.toLowerCase() &&
+                    Boolean(p.householdId18)
+            );
+            if (match?.householdId18) {
+                setSelectedOrg({ name: match.name, householdId18: match.householdId18 });
+            }
+        }
     }, [partnerOrganizations, selectedOrg, setSelectedOrg]);
 
     // Sync selected org into URL
     const handleSelectOrg = (org: { name: string; householdId18?: string | null }) => {
         setSelectedOrg(org);
         const params = new URLSearchParams(searchParams.toString());
+        params.delete('householdId18');
+        params.delete('destination');
         if (org.householdId18) {
             params.set('householdId18', org.householdId18);
-        } else {
-            params.delete('householdId18');
+        } else if (org.name?.trim()) {
+            params.set('destination', org.name.trim());
         }
         router.push(`?${params.toString()}`);
     };
@@ -182,6 +201,7 @@ function DistributionContent() {
         clearSelectedOrg();
         const params = new URLSearchParams(searchParams.toString());
         params.delete('householdId18');
+        params.delete('destination');
         router.push(`?${params.toString()}`);
     };
 
@@ -231,7 +251,15 @@ function DistributionContent() {
         const ac = new AbortController();
         async function fetchFilterOptions() {
             try {
-                const res = await fetch('/api/distribution/filter-options', { signal: ac.signal });
+                const optParams = new URLSearchParams();
+                if (selectedOrg?.householdId18)
+                    optParams.set('householdId18', selectedOrg.householdId18);
+                else if (selectedOrg?.name?.trim())
+                    optParams.set('destination', selectedOrg.name.trim());
+                const q = optParams.toString();
+                const res = await fetch(`/api/distribution/filter-options${q ? `?${q}` : ''}`, {
+                    signal: ac.signal,
+                });
                 if (!res.ok) return;
                 const payload = (await res.json()) as { productTypes?: string[] };
                 if (ac.signal.aborted) return;
@@ -245,7 +273,7 @@ function DistributionContent() {
         }
         void fetchFilterOptions();
         return () => ac.abort();
-    }, []);
+    }, [selectedOrg]);
 
     const availableProductTypesSorted = useMemo(() => {
         const byKey = new Map<string, string>();
@@ -491,6 +519,8 @@ thead th{background:#f3f4f6;font-weight:600;}
                 });
                 if (selectedOrg?.householdId18)
                     deliveriesParams.set('householdId18', selectedOrg.householdId18);
+                else if (selectedOrg?.name?.trim())
+                    deliveriesParams.set('destination', selectedOrg.name.trim());
                 const res = await fetch(
                     `/api/distribution/deliveries?${deliveriesParams.toString()}`,
                     {
@@ -979,7 +1009,7 @@ thead th{background:#f3f4f6;font-weight:600;}
                                                       : undefined;
                                             const rowKey = d.lineId
                                                 ? `je-${d.lineId}`
-                                                : `br-${d.householdId18}-${String(d.date)}-${d.productName ?? ''}-${amt}-${startIdx + index}`;
+                                                : `br-${d.householdId18 ?? 'nodest'}-${d.organizationName}-${String(d.date)}-${d.productName ?? ''}-${amt}-${startIdx + index}`;
                                             return (
                                                 <tr
                                                     key={rowKey}

--- a/src/app/(dashboard)/overview/page.tsx
+++ b/src/app/(dashboard)/overview/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { StatCard } from '@/components/ui/StatCard';
 import { FoodTypesDonutChart } from '@/components/ui/FoodTypesDonutChart';
 import { PoundsByMonthChart } from '@/components/ui/PoundsByMonthChart';
@@ -38,7 +38,19 @@ const formatDateParam = (d: Date) => {
 };
 
 const OverviewPageContent: React.FC = () => {
+    const router = useRouter();
+    const pathname = usePathname();
     const searchParams = useSearchParams();
+
+    const replaceSearchParams = useCallback(
+        (mutate: (p: URLSearchParams) => void) => {
+            const p = new URLSearchParams(searchParams.toString());
+            mutate(p);
+            const qs = p.toString();
+            router.replace(qs ? `${pathname}?${qs}` : pathname);
+        },
+        [pathname, router, searchParams]
+    );
     const { isAdmin, partnerOrganizationName, partnerHouseholdId18 } = useViewerContext();
 
     const { dateRange } = useFilterContext();
@@ -58,13 +70,40 @@ const OverviewPageContent: React.FC = () => {
     useEffect(() => {
         if (!isAdmin) return;
         const householdId18 = searchParams.get('householdId18')?.trim();
+        const destination = searchParams.get('destination')?.trim();
         if (householdId18) {
-            // Set scope immediately from URL, then hydrate display name once partners load.
-            setSelectedOrg(current =>
-                current?.householdId18 === householdId18 ? current : { name: '', householdId18 }
-            );
+            setSelectedOrg(current => {
+                if (current?.householdId18 === householdId18) return current;
+                const fromList = partnerOrganizations.find(
+                    org => org.householdId18 === householdId18
+                );
+                if (fromList) {
+                    return { name: fromList.name, householdId18 };
+                }
+                if (current?.name?.trim()) {
+                    return { name: current.name, householdId18 };
+                }
+                return { name: '', householdId18 };
+            });
+        } else if (destination) {
+            setSelectedOrg(current => {
+                if (current?.householdId18) {
+                    const match = partnerOrganizations.find(
+                        org => org.householdId18 === current.householdId18
+                    );
+                    if (
+                        match &&
+                        match.name.trim().toLowerCase() === destination.trim().toLowerCase()
+                    ) {
+                        return current;
+                    }
+                }
+                return current?.name === destination && current?.householdId18 == null
+                    ? current
+                    : { name: destination, householdId18: null };
+            });
         }
-    }, [isAdmin, searchParams, setSelectedOrg]);
+    }, [isAdmin, searchParams, setSelectedOrg, partnerOrganizations]);
 
     useEffect(() => {
         if (!isAdmin) return;
@@ -137,6 +176,8 @@ const OverviewPageContent: React.FC = () => {
         const params = new URLSearchParams({ start, end });
         if (selectedPartner?.householdId18)
             params.set('householdId18', selectedPartner.householdId18);
+        else if (selectedPartner?.name?.trim())
+            params.set('destination', selectedPartner.name.trim());
         const q = params.toString();
 
         setLoading(true);
@@ -230,7 +271,13 @@ const OverviewPageContent: React.FC = () => {
                                 <span className="mx-2 text-gray-300">·</span>
                                 <button
                                     type="button"
-                                    onClick={clearSelectedOrg}
+                                    onClick={() => {
+                                        clearSelectedOrg();
+                                        replaceSearchParams(p => {
+                                            p.delete('householdId18');
+                                            p.delete('destination');
+                                        });
+                                    }}
                                     className="text-[#1C5E2C] font-medium underline underline-offset-2 hover:text-[#164a22]"
                                 >
                                     View all organizations
@@ -242,9 +289,25 @@ const OverviewPageContent: React.FC = () => {
                         <div className="w-full max-w-[17.5rem] shrink-0 self-start sm:max-w-sm lg:w-auto lg:pt-1">
                             <SearchBarOverview
                                 organizations={partnerOrganizations}
-                                onSelectPartner={partner => setSelectedOrg(partner)}
+                                onSelectPartner={partner => {
+                                    setSelectedOrg(partner);
+                                    replaceSearchParams(p => {
+                                        p.delete('householdId18');
+                                        p.delete('destination');
+                                        if (partner.householdId18)
+                                            p.set('householdId18', partner.householdId18);
+                                        else if (partner.name?.trim())
+                                            p.set('destination', partner.name.trim());
+                                    });
+                                }}
                                 selectedPartner={selectedPartner}
-                                onClearPartner={clearSelectedOrg}
+                                onClearPartner={() => {
+                                    clearSelectedOrg();
+                                    replaceSearchParams(p => {
+                                        p.delete('householdId18');
+                                        p.delete('destination');
+                                    });
+                                }}
                             />
                         </div>
                     ) : null}
@@ -386,7 +449,9 @@ const OverviewPageContent: React.FC = () => {
                                             href={
                                                 selectedPartner?.householdId18
                                                     ? `/distribution?householdId18=${encodeURIComponent(selectedPartner.householdId18)}`
-                                                    : '/distribution'
+                                                    : selectedPartner?.name?.trim()
+                                                      ? `/distribution?destination=${encodeURIComponent(selectedPartner.name.trim())}`
+                                                      : '/distribution'
                                             }
                                             className="inline-flex items-center justify-center rounded-lg border border-transparent px-5 py-2 text-sm font-medium text-black shadow-sm transition-colors hover:opacity-90"
                                             style={{ backgroundColor: 'var(--fff-orange)' }}

--- a/src/app/api/admin/organizations/route.ts
+++ b/src/app/api/admin/organizations/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { auth, clerkClient } from '@clerk/nextjs/server';
 import { requireAdmin } from '@/lib/admin';
@@ -74,28 +75,30 @@ export async function POST(req: NextRequest) {
         await requireAdmin();
 
         const body = await req.json();
-        const { name, householdId18 } = body;
+        const { name, householdId18 } = body as {
+            name?: string;
+            householdId18?: string | null;
+        };
 
         if (!name) {
             return NextResponse.json({ error: 'Organization name is required' }, { status: 400 });
         }
-        if (!householdId18 || !householdId18.trim()) {
-            return NextResponse.json({ error: 'Household Id 18 is required' }, { status: 400 });
-        }
+
+        const trimmedId =
+            typeof householdId18 === 'string' && householdId18.trim() ? householdId18.trim() : null;
+        const syntheticHouseholdId18 = trimmedId ?? `pending-${randomUUID().replace(/-/g, '')}`;
 
         const client = await clerkClient();
 
-        // Create organization in Clerk
         const organization = await client.organizations.createOrganization({
             name,
             createdBy: userId,
-            publicMetadata: { householdId18: householdId18.trim() },
+            publicMetadata: trimmedId ? { householdId18: trimmedId } : {},
         });
 
-        // Create matching Partner in Neon so webhook can associate users with this org
         await prisma.partner.create({
             data: {
-                householdId18: householdId18.trim(),
+                householdId18: syntheticHouseholdId18,
                 organizationName: name,
                 clerkOrganizationId: organization.id,
             },

--- a/src/app/api/distribution/deliveries/route.ts
+++ b/src/app/api/distribution/deliveries/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '~/lib/prisma';
+import type { OverviewScope } from '~/lib/overviewAccess';
 import {
     getOverviewScope,
     overviewScopeErrorResponse,
-    scopeToPartnerHouseholdId18,
+    scopeEffectiveHouseholdId18,
 } from '~/lib/overviewAccess';
 import {
+    distributionOrgScopeFromOverview,
     queryDistributionDeliveries,
     queryJustEatsDistributionDeliveries,
 } from '~/lib/distributionDeliveries';
+
+function destinationLabel(scope: OverviewScope): string | undefined {
+    if (scope.kind === 'partner' || scope.kind === 'admin') {
+        return scope.destination?.trim();
+    }
+    return undefined;
+}
 
 /**
  * GET /api/distribution/deliveries?start=&end=&search=&destination=
@@ -36,21 +45,24 @@ export async function GET(req: NextRequest) {
     }
 
     const search = (searchParams.get('search') || '').trim().toLowerCase();
-    const partnerHouseholdId18 = scopeToPartnerHouseholdId18(scope);
+    const partnerHouseholdId18 = scopeEffectiveHouseholdId18(scope);
+    const orgFilter = partnerHouseholdId18 ? undefined : distributionOrgScopeFromOverview(scope);
+    const destForOrphan = partnerHouseholdId18 ? destinationLabel(scope) : undefined;
 
     const [bulk, justEats] = await Promise.all([
         queryDistributionDeliveries(prisma, {
             start,
             end,
             search,
-            orgFilter: undefined,
+            orgFilter,
             partnerHouseholdId18,
+            destinationLabel: destForOrphan,
         }),
         queryJustEatsDistributionDeliveries(prisma, {
             start,
             end,
             search,
-            orgFilter: undefined,
+            orgFilter,
             partnerHouseholdId18,
         }),
     ]);

--- a/src/app/api/distribution/filter-options/route.ts
+++ b/src/app/api/distribution/filter-options/route.ts
@@ -1,17 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import prisma from '~/lib/prisma';
 import {
     getOverviewScope,
     overviewScopeErrorResponse,
-    scopeToPartnerHouseholdId18,
+    scopeEffectiveHouseholdId18,
+    scopeOrganizationNameFilter,
 } from '~/lib/overviewAccess';
 import { foodTypeLabelForRow } from '~/lib/chartCompositionColors';
+import {
+    distributionInventoryTypeCondition,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 
 type ProductTypeRow = { productType: string | null };
 
 /**
  * GET /api/distribution/filter-options
- * Returns distinct food type filter options for current viewer scope.
+ * Distinct food types for the current scope (joined pipeline + orphan distribution inventory).
  */
 export async function GET(req: NextRequest) {
     try {
@@ -23,22 +29,49 @@ export async function GET(req: NextRequest) {
         const scopeErr = overviewScopeErrorResponse(scope);
         if (scopeErr) return scopeErr;
 
-        const partnerHouseholdId18 = scopeToPartnerHouseholdId18(scope);
+        const hh = scopeEffectiveHouseholdId18(scope);
+        const orgNameOnly = scopeOrganizationNameFilter(scope);
+        const destLabel =
+            scope.kind === 'partner' || scope.kind === 'admin'
+                ? (scope.destination?.trim() ?? '')
+                : '';
 
-        const rows = partnerHouseholdId18
-            ? await prisma.$queryRaw<ProductTypeRow[]>`
-                SELECT DISTINCT t."productType" AS "productType"
+        const joinedClause = hh
+            ? Prisma.sql`WHERE d."householdId18" = ${hh}`
+            : orgNameOnly
+              ? Prisma.sql`WHERE LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))`
+              : Prisma.sql``;
+
+        const orphanClause =
+            orgNameOnly != null
+                ? Prisma.sql`AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${orgNameOnly}))`
+                : hh && destLabel.length > 0
+                  ? Prisma.sql`AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${destLabel}))`
+                  : hh
+                    ? Prisma.sql`AND FALSE`
+                    : Prisma.sql``;
+
+        const rows = await prisma.$queryRaw<ProductTypeRow[]>`
+            SELECT DISTINCT t."productType" AS "productType"
+            FROM (
+                SELECT t."productType"
                 FROM "AllInventoryTransactions" t
                 INNER JOIN "AllPackagesByItem" p
                     ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
                 INNER JOIN "AllProductPackageDestinations" d
                     ON d."productPackageId18" = p."productPackageId18"
-                WHERE d."householdId18" = ${partnerHouseholdId18}
-            `
-            : await prisma.$queryRaw<ProductTypeRow[]>`
-                SELECT DISTINCT t."productType" AS "productType"
+                LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                ${joinedClause}
+
+                UNION
+
+                SELECT t."productType"
                 FROM "AllInventoryTransactions" t
-            `;
+                WHERE ${distributionInventoryTypeCondition}
+                  AND ${orphanInventoryCondition}
+                  ${orphanClause}
+            ) t
+        `;
 
         const unique = new Set<string>();
         for (const row of rows) {

--- a/src/app/api/overview/deliveries/detail/route.ts
+++ b/src/app/api/overview/deliveries/detail/route.ts
@@ -1,7 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import prisma from '~/lib/prisma';
-import { getOverviewScope, overviewScopeErrorResponse } from '~/lib/overviewAccess';
+import {
+    getOverviewScope,
+    overviewScopeErrorResponse,
+    scopeEffectiveHouseholdId18,
+    scopeOrganizationNameFilter,
+} from '~/lib/overviewAccess';
+import {
+    distributionInventoryTypeCondition,
+    inventoryTxPoundsSql,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 
 type FoodRow = { productName: string | null; totalWeightLbs: number | null };
 
@@ -18,23 +28,41 @@ function buildNutritionalTags(rows: TagRow[]): string[] {
         if (r.minimallyProcessedFood === false) anyFalse = true;
     }
     const tags = [...types].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
-    // Omit "Mixed processing" for this view; when both apply, show no aggregate processing tag.
     if (anyTrue && !anyFalse) tags.push('Minimally processed');
     else if (!anyTrue && anyFalse) tags.push('Processed');
     else if (rows.length > 0 && !anyTrue && !anyFalse) tags.push('Not specified');
     return tags;
 }
 
+function mergeFoodMaps(maps: Map<string, number>[]): Map<string, number> {
+    const out = new Map<string, number>();
+    for (const m of maps) {
+        for (const [k, v] of m) {
+            out.set(k, (out.get(k) ?? 0) + v);
+        }
+    }
+    return out;
+}
+
+function rowsToMap(rows: FoodRow[]): Map<string, number> {
+    const m = new Map<string, number>();
+    for (const r of rows) {
+        const name = r.productName?.trim() || 'Unknown';
+        m.set(name, (m.get(name) ?? 0) + Number(r.totalWeightLbs ?? 0));
+    }
+    return m;
+}
+
 /**
- * GET /api/overview/deliveries/detail?date=YYYY-MM-DD&org=OrgName
- * Returns itemized foods delivered for a specific date + organization.
- * Admin: any org. Partner: only their own org.
+ * GET /api/overview/deliveries/detail?date=YYYY-MM-DD&org=OrgName&householdId18=&destination=
  */
 export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const dateParam = searchParams.get('date');
     const org = searchParams.get('org')?.trim() ?? '';
     const householdId18Param = searchParams.get('householdId18')?.trim() ?? '';
+    const destinationParam =
+        searchParams.get('destination')?.trim() ?? searchParams.get('org')?.trim() ?? '';
 
     if (!dateParam) {
         return NextResponse.json({ error: 'Missing date parameter' }, { status: 400 });
@@ -45,15 +73,17 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'Invalid date' }, { status: 400 });
     }
 
-    const scope = await getOverviewScope(null, householdId18Param);
+    const scope = await getOverviewScope(destinationParam || null, householdId18Param || null);
     const scopeErr = overviewScopeErrorResponse(scope);
     if (scopeErr) return scopeErr;
 
-    if (scope.kind === 'admin' && !householdId18Param) {
-        return NextResponse.json({ error: 'Missing householdId18 parameter' }, { status: 400 });
+    if (scope.kind === 'admin' && !householdId18Param && !(destinationParam || org)) {
+        return NextResponse.json(
+            { error: 'Missing householdId18 or destination parameter' },
+            { status: 400 }
+        );
     }
 
-    // Partners can only view their own org's data
     if (
         scope.kind === 'partner' &&
         householdId18Param &&
@@ -62,71 +92,127 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
+    if (
+        scope.kind === 'partner' &&
+        !householdId18Param &&
+        destinationParam &&
+        scope.destination?.trim().toLowerCase() !== destinationParam.trim().toLowerCase()
+    ) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
     try {
-        const destinationPredicate =
-            scope.kind === 'partner'
-                ? Prisma.sql`d."householdId18" = ${scope.partnerHouseholdId18}`
-                : householdId18Param
-                  ? Prisma.sql`d."householdId18" = ${householdId18Param}`
-                  : Prisma.empty;
+        const hh = scopeEffectiveHouseholdId18(scope);
+        const orgNameOnly = scopeOrganizationNameFilter(scope);
+        const destLabel = (destinationParam || org).trim();
+
+        const joinedPartnerPredicate = hh
+            ? Prisma.sql`d."householdId18" = ${hh}`
+            : orgNameOnly
+              ? Prisma.sql`LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))`
+              : destLabel.length > 0
+                ? Prisma.sql`LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${destLabel}))`
+                : Prisma.sql`FALSE`;
+
+        const orphanPredicate =
+            orgNameOnly != null
+                ? Prisma.sql`AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${orgNameOnly}))`
+                : hh && destLabel.length > 0
+                  ? Prisma.sql`AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${destLabel}))`
+                  : destLabel.length > 0
+                    ? Prisma.sql`AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${destLabel}))`
+                    : Prisma.sql`AND FALSE`;
 
         const justEatsHouseholdPredicate =
-            scope.kind === 'partner'
+            scope.kind === 'partner' && householdId18Param
                 ? Prisma.sql`t."householdId" = ${scope.partnerHouseholdId18}`
                 : householdId18Param
                   ? Prisma.sql`t."householdId" = ${householdId18Param}`
-                  : Prisma.empty;
+                  : destLabel.length > 0
+                    ? Prisma.sql`LOWER(TRIM(t."householdName")) = LOWER(TRIM(${destLabel}))`
+                    : Prisma.sql`FALSE`;
 
-        // Use pantry visit date (d.date) to match overview delivery day grouping.
-        const foodRows = await prisma.$queryRaw<FoodRow[]>`
-            SELECT
-                COALESCE(p."pantryProductName", 'Unknown') AS "productName",
-                SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "totalWeightLbs"
-            FROM "AllInventoryTransactions" t
-            INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
-            INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
-            WHERE DATE_TRUNC('day', d."date") = DATE_TRUNC('day', ${date})
-              AND ${destinationPredicate}
-            GROUP BY p."pantryProductName"
+        const [joinedFood, orphanFood, jeFood, tagJoined, tagOrphan] = await Promise.all([
+            prisma.$queryRaw<FoodRow[]>`
+                SELECT
+                    COALESCE(p."pantryProductName", 'Unknown') AS "productName",
+                    SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "totalWeightLbs"
+                FROM "AllInventoryTransactions" t
+                INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+                INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
+                LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                WHERE DATE_TRUNC('day', d."date") = DATE_TRUNC('day', ${date})
+                  AND ${joinedPartnerPredicate}
+                GROUP BY p."pantryProductName"
+            `,
+            prisma.$queryRaw<FoodRow[]>`
+                SELECT
+                    COALESCE(t."pantryProductName", 'Unknown') AS "productName",
+                    SUM(${inventoryTxPoundsSql()}) AS "totalWeightLbs"
+                FROM "AllInventoryTransactions" t
+                WHERE DATE_TRUNC('day', t."date") = DATE_TRUNC('day', ${date})
+                  AND ${distributionInventoryTypeCondition}
+                  AND ${orphanInventoryCondition}
+                  ${orphanPredicate}
+                GROUP BY t."pantryProductName"
+            `,
+            prisma.$queryRaw<FoodRow[]>`
+                SELECT
+                    COALESCE(t."productPackageName", 'Unknown') AS "productName",
+                    COUNT(*) * 25 AS "totalWeightLbs"
+                FROM "JustEatsBoxes" t
+                WHERE DATE_TRUNC('day', t."pantryVisitDateTime") = DATE_TRUNC('day', ${date})
+                  AND ${justEatsHouseholdPredicate}
+                GROUP BY t."productPackageName"
+            `,
+            prisma.$queryRaw<TagRow[]>`
+                SELECT DISTINCT t."productType", t."minimallyProcessedFood"
+                FROM "AllInventoryTransactions" t
+                INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+                INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
+                LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                WHERE DATE_TRUNC('day', d."date") = DATE_TRUNC('day', ${date})
+                  AND ${joinedPartnerPredicate}
+            `,
+            prisma.$queryRaw<TagRow[]>`
+                SELECT DISTINCT t."productType", t."minimallyProcessedFood"
+                FROM "AllInventoryTransactions" t
+                WHERE DATE_TRUNC('day', t."date") = DATE_TRUNC('day', ${date})
+                  AND ${distributionInventoryTypeCondition}
+                  AND ${orphanInventoryCondition}
+                  ${orphanPredicate}
+            `,
+        ]);
 
-            UNION ALL 
+        const foodMap = mergeFoodMaps([
+            rowsToMap(joinedFood),
+            rowsToMap(orphanFood),
+            rowsToMap(jeFood),
+        ]);
 
-            SELECT
-                COALESCE(t."productPackageName", 'Unknown') AS "productName",
-                COUNT(*) * 25 AS "totalWeightLbs"
-            FROM "JustEatsBoxes" t
-            WHERE DATE_TRUNC('day', t."pantryVisitDateTime") = DATE_TRUNC('day', ${date})
-              AND ${justEatsHouseholdPredicate}
-            GROUP BY t."productPackageName"
+        const foodRowsSorted = [...foodMap.entries()]
+            .map(([name, lbs]) => ({
+                productName: name,
+                totalWeightLbs: lbs,
+            }))
+            .sort((a, b) => b.totalWeightLbs - a.totalWeightLbs);
 
-            ORDER BY "totalWeightLbs" DESC
-        `;
+        const totalPounds = foodRowsSorted.reduce((sum, r) => sum + r.totalWeightLbs, 0);
 
-        const totalPounds = foodRows.reduce((sum, r) => sum + Number(r.totalWeightLbs ?? 0), 0);
-
-        const tagRows = await prisma.$queryRaw<TagRow[]>`
-            SELECT DISTINCT t."productType", t."minimallyProcessedFood"
-            FROM "AllInventoryTransactions" t
-            INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
-            INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
-            WHERE DATE_TRUNC('day', d."date") = DATE_TRUNC('day', ${date})
-              AND ${destinationPredicate}
-        `;
-
-        const nutritionalTags = buildNutritionalTags(tagRows);
+        const nutritionalTags = buildNutritionalTags([...tagJoined, ...tagOrphan]);
 
         return NextResponse.json({
             date: date.toISOString().slice(0, 10),
             organizationName:
-                org || (scope.kind === 'partner' ? scope.destination : 'Selected Organization'),
+                org ||
+                destinationParam ||
+                (scope.kind === 'partner' ? scope.destination : 'Selected Organization'),
             totalPounds: Math.round(totalPounds),
             nutritionalTags,
-            foodsDelivered: foodRows
-                .filter(r => r.productName)
-                .map(r => ({
-                    name: r.productName!,
-                    weight: `${Math.round(Number(r.totalWeightLbs ?? 0)).toLocaleString()} lbs`,
-                })),
+            foodsDelivered: foodRowsSorted.map(r => ({
+                name: r.productName,
+                weight: `${Math.round(r.totalWeightLbs).toLocaleString()} lbs`,
+            })),
         });
     } catch (err: unknown) {
         console.error('Delivery detail error:', err);

--- a/src/app/api/overview/deliveries/route.ts
+++ b/src/app/api/overview/deliveries/route.ts
@@ -124,7 +124,7 @@ export async function GET(request: NextRequest) {
                     LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
                     WHERE d."date" >= ${range.start}
                       AND d."date" <= ${range.end}
-                      AND LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))
+                      AND LOWER(TRIM(d."householdName")) = LOWER(TRIM(${orgNameOnly}))
                     GROUP BY DATE_TRUNC('day', d."date")
                     HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
                 `,
@@ -133,9 +133,26 @@ export async function GET(request: NextRequest) {
                         TO_CHAR(DATE_TRUNC('day', j."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
                         COUNT(*) * 25 AS "totalPounds"
                     FROM "JustEatsBoxes" j
+                    LEFT JOIN "Partner" pt ON pt."householdId18" = j."householdId"
                     WHERE j."pantryVisitDateTime" >= ${range.start}
                       AND j."pantryVisitDateTime" <= ${range.end}
                       AND LOWER(TRIM(j."householdName")) = LOWER(TRIM(${orgNameOnly}))
+                      AND EXISTS (
+                          SELECT 1
+                          FROM (
+                              SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                              FROM "AllProductPackageDestinations" d2
+                              WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                              UNION
+
+                              SELECT LOWER(TRIM(t2."destination")) AS org_name
+                              FROM "AllInventoryTransactions" t2
+                              WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                                AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+                          ) valid_orgs
+                          WHERE valid_orgs.org_name = LOWER(TRIM(j."householdName"))
+                      )
                     GROUP BY DATE_TRUNC('day', j."pantryVisitDateTime")
                     HAVING COUNT(*) * 25 > 0
                 `,
@@ -232,9 +249,26 @@ export async function GET(request: NextRequest) {
                         TO_CHAR(DATE_TRUNC('day', t."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
                         COUNT(*) * 25 AS "totalPounds"
                     FROM "JustEatsBoxes" t
+                    LEFT JOIN "Partner" pt ON pt."householdId18" = t."householdId"
                     WHERE t."householdId" = ${hh}
                       AND t."pantryVisitDateTime" >= ${range.start}
                       AND t."pantryVisitDateTime" <= ${range.end}
+                      AND EXISTS (
+                          SELECT 1
+                          FROM (
+                              SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                              FROM "AllProductPackageDestinations" d2
+                              WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                              UNION
+
+                              SELECT LOWER(TRIM(t2."destination")) AS org_name
+                              FROM "AllInventoryTransactions" t2
+                              WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                                AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+                          ) valid_orgs
+                          WHERE valid_orgs.org_name = LOWER(TRIM(t."householdName"))
+                      )
                     GROUP BY DATE_TRUNC('day', t."pantryVisitDateTime")
                     HAVING COUNT(*) * 25 > 0
                 `,
@@ -365,6 +399,23 @@ export async function GET(request: NextRequest) {
                 LEFT JOIN "Partner" pt ON pt."householdId18" = t."householdId"
                 WHERE t."pantryVisitDateTime" >= ${range.start}
                   AND t."pantryVisitDateTime" <= ${range.end}
+                  AND TRIM(COALESCE(t."householdName", '')) <> ''
+                  AND EXISTS (
+                      SELECT 1
+                      FROM (
+                          SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                          FROM "AllProductPackageDestinations" d2
+                          WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                          UNION
+
+                          SELECT LOWER(TRIM(t2."destination")) AS org_name
+                          FROM "AllInventoryTransactions" t2
+                          WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                            AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+                      ) valid_orgs
+                      WHERE valid_orgs.org_name = LOWER(TRIM(t."householdName"))
+                  )
                 GROUP BY DATE_TRUNC('day', t."pantryVisitDateTime"), t."householdId", COALESCE(pt."organizationName", t."householdName"), 'just_eats'::text
                 HAVING COUNT(*) * 25 > 0
             `,

--- a/src/app/api/overview/deliveries/route.ts
+++ b/src/app/api/overview/deliveries/route.ts
@@ -1,10 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '~/lib/prisma';
+import { normalizeDestinationName } from '~/lib/destinationNameFilter';
+import type { OverviewScope } from '~/lib/overviewAccess';
 import {
     getOverviewScope,
     overviewScopeErrorResponse,
-    scopeToPartnerHouseholdId18,
+    scopeEffectiveHouseholdId18,
+    scopeOrganizationNameFilter,
 } from '~/lib/overviewAccess';
+import {
+    distributionInventoryTypeCondition,
+    inventoryTxPoundsSql,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 
 function parseDateRange(searchParams: URLSearchParams): { start: Date; end: Date } | null {
     const startParam = searchParams.get('start');
@@ -38,9 +46,39 @@ function getDefaultRange(): { start: Date; end: Date } {
     return { start, end };
 }
 
+function destinationLabel(scope: OverviewScope): string {
+    if (scope.kind === 'partner' || scope.kind === 'admin') {
+        return scope.destination?.trim() ?? '';
+    }
+    return '';
+}
+
+type DeliveryOut = {
+    id: string;
+    date: string;
+    totalPounds: number;
+    destination: string;
+    householdId18: string | null;
+    program: 'bulk_rescue' | 'just_eats';
+};
+
+function mergeDeliveryBuckets(rows: DeliveryOut[]): DeliveryOut[] {
+    const map = new Map<string, DeliveryOut>();
+    for (const r of rows) {
+        const destKey = normalizeDestinationName(r.destination);
+        const key = `${r.date}|${destKey}|${r.program}|${r.householdId18 ?? ''}`;
+        const prev = map.get(key);
+        if (!prev) {
+            map.set(key, { ...r });
+        } else {
+            prev.totalPounds += r.totalPounds;
+        }
+    }
+    return [...map.values()];
+}
+
 /**
  * GET /api/overview/deliveries?start=...&end=...&destination=...&householdId18=...
- * Bulk & Rescue plus Just Eats (25 lb/box). Bulk & Rescue excludes zero-pound day totals; scoped rows match overview scope.
  */
 export async function GET(request: NextRequest) {
     try {
@@ -53,22 +91,28 @@ export async function GET(request: NextRequest) {
         if (scopeErr) return scopeErr;
 
         const range = parseDateRange(searchParams) ?? getDefaultRange();
-        const partnerHouseholdId18 = scopeToPartnerHouseholdId18(scope);
+        const hh = scopeEffectiveHouseholdId18(scope);
+        const orgNameOnly = scopeOrganizationNameFilter(scope);
 
-        // Use d.date (pantry visit date/time) as the delivery day source.
-        if (partnerHouseholdId18) {
-            const scopedDestinationName =
-                scope.kind === 'admin' || scope.kind === 'partner' ? scope.destination : undefined;
-            type PartnerDeliveryRow = {
-                day: string;
-                destination: string | null;
-                totalPounds: number | null;
-            };
-            type PartnerJustEatsRow = {
-                day: string;
-                totalPounds: number | null;
-            };
-            const [brRows, jeRows] = await Promise.all([
+        type PartnerDeliveryRow = {
+            day: string;
+            destination: string | null;
+            totalPounds: number | null;
+        };
+        type PartnerJustEatsRow = {
+            day: string;
+            totalPounds: number | null;
+        };
+        type OrphanDayRow = {
+            day: string;
+            totalPounds: number | null;
+        };
+
+        const scopedDestinationName =
+            scope.kind === 'admin' || scope.kind === 'partner' ? scope.destination : undefined;
+
+        if (orgNameOnly) {
+            const [brRows, jeRows, orRows] = await Promise.all([
                 prisma.$queryRaw<PartnerDeliveryRow[]>`
                     SELECT
                         TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
@@ -78,7 +122,106 @@ export async function GET(request: NextRequest) {
                     INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
                     INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
                     LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
-                    WHERE d."householdId18" = ${partnerHouseholdId18}
+                    WHERE d."date" >= ${range.start}
+                      AND d."date" <= ${range.end}
+                      AND LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))
+                    GROUP BY DATE_TRUNC('day', d."date")
+                    HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
+                `,
+                prisma.$queryRaw<PartnerJustEatsRow[]>`
+                    SELECT
+                        TO_CHAR(DATE_TRUNC('day', j."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+                        COUNT(*) * 25 AS "totalPounds"
+                    FROM "JustEatsBoxes" j
+                    WHERE j."pantryVisitDateTime" >= ${range.start}
+                      AND j."pantryVisitDateTime" <= ${range.end}
+                      AND LOWER(TRIM(j."householdName")) = LOWER(TRIM(${orgNameOnly}))
+                    GROUP BY DATE_TRUNC('day', j."pantryVisitDateTime")
+                    HAVING COUNT(*) * 25 > 0
+                `,
+                prisma.$queryRaw<OrphanDayRow[]>`
+                    SELECT
+                        TO_CHAR(DATE_TRUNC('day', t."date"), 'YYYY-MM-DD') AS "day",
+                        SUM(${inventoryTxPoundsSql()}) AS "totalPounds"
+                    FROM "AllInventoryTransactions" t
+                    WHERE t."date" >= ${range.start}
+                      AND t."date" <= ${range.end}
+                      AND ${distributionInventoryTypeCondition}
+                      AND ${orphanInventoryCondition}
+                      AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${orgNameOnly}))
+                    GROUP BY DATE_TRUNC('day', t."date")
+                    HAVING SUM(${inventoryTxPoundsSql()}) > 0
+                `,
+            ]);
+
+            const orphanByDay = new Map(
+                orRows.map(r => [r.day, Math.round(Number(r.totalPounds ?? 0))])
+            );
+
+            const mergedBr: DeliveryOut[] = [];
+            for (const r of brRows) {
+                const day = r.day;
+                const extra = orphanByDay.get(day) ?? 0;
+                if (extra) orphanByDay.delete(day);
+                mergedBr.push({
+                    id: `${day}|name-br|bulk_rescue`,
+                    date: `${day}T00:00:00.000Z`,
+                    totalPounds: Math.round(Number(r.totalPounds ?? 0)) + extra,
+                    destination: r.destination?.trim() || scopedDestinationName || orgNameOnly,
+                    householdId18: null,
+                    program: 'bulk_rescue',
+                });
+            }
+            for (const [day, lbs] of orphanByDay) {
+                if (lbs <= 0) continue;
+                mergedBr.push({
+                    id: `${day}|name-orphan|bulk_rescue`,
+                    date: `${day}T00:00:00.000Z`,
+                    totalPounds: lbs,
+                    destination: scopedDestinationName || orgNameOnly,
+                    householdId18: null,
+                    program: 'bulk_rescue',
+                });
+            }
+
+            const jeOut: DeliveryOut[] = jeRows.map(r => ({
+                id: `${r.day}|name|just_eats`,
+                date: `${r.day}T00:00:00.000Z`,
+                totalPounds: Math.round(Number(r.totalPounds ?? 0)),
+                destination: scopedDestinationName || orgNameOnly,
+                householdId18: null,
+                program: 'just_eats',
+            }));
+
+            const merged = mergeDeliveryBuckets([...mergedBr, ...jeOut]).sort((a, b) =>
+                a.date < b.date ? 1 : a.date > b.date ? -1 : 0
+            );
+
+            return NextResponse.json({
+                deliveries: merged.slice(0, 10).map(r => ({
+                    id: r.id,
+                    date: r.date,
+                    totalPounds: r.totalPounds,
+                    destination: r.destination,
+                    householdId18: r.householdId18,
+                    program: r.program,
+                })),
+            });
+        }
+
+        if (hh) {
+            const destLabel = destinationLabel(scope);
+            const [brRows, jeRows, orRows] = await Promise.all([
+                prisma.$queryRaw<PartnerDeliveryRow[]>`
+                    SELECT
+                        TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
+                        COALESCE(MAX(pt."organizationName"), MAX(d."householdName")) AS "destination",
+                        SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "totalPounds"
+                    FROM "AllInventoryTransactions" t
+                    INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+                    INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
+                    LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                    WHERE d."householdId18" = ${hh}
                       AND d."date" >= ${range.start}
                       AND d."date" <= ${range.end}
                     GROUP BY DATE_TRUNC('day', d."date")
@@ -89,52 +232,87 @@ export async function GET(request: NextRequest) {
                         TO_CHAR(DATE_TRUNC('day', t."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
                         COUNT(*) * 25 AS "totalPounds"
                     FROM "JustEatsBoxes" t
-                    WHERE t."householdId" = ${partnerHouseholdId18}
+                    WHERE t."householdId" = ${hh}
                       AND t."pantryVisitDateTime" >= ${range.start}
                       AND t."pantryVisitDateTime" <= ${range.end}
                     GROUP BY DATE_TRUNC('day', t."pantryVisitDateTime")
                     HAVING COUNT(*) * 25 > 0
                 `,
+                destLabel.length > 0
+                    ? prisma.$queryRaw<OrphanDayRow[]>`
+                        SELECT
+                            TO_CHAR(DATE_TRUNC('day', t."date"), 'YYYY-MM-DD') AS "day",
+                            SUM(${inventoryTxPoundsSql()}) AS "totalPounds"
+                        FROM "AllInventoryTransactions" t
+                        WHERE t."date" >= ${range.start}
+                          AND t."date" <= ${range.end}
+                          AND ${distributionInventoryTypeCondition}
+                          AND ${orphanInventoryCondition}
+                          AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${destLabel}))
+                        GROUP BY DATE_TRUNC('day', t."date")
+                        HAVING SUM(${inventoryTxPoundsSql()}) > 0
+                    `
+                    : Promise.resolve([] as OrphanDayRow[]),
             ]);
 
-            const destinationForRow =
-                brRows[0]?.destination?.trim() || scopedDestinationName || partnerHouseholdId18;
+            const orphanByDay = new Map(
+                orRows.map(r => [r.day, Math.round(Number(r.totalPounds ?? 0))])
+            );
 
-            type PartnerMerged = {
-                day: string;
-                program: 'bulk_rescue' | 'just_eats';
-                totalPounds: number;
-                destination: string;
-            };
-            const merged: PartnerMerged[] = [
-                ...brRows.map(r => ({
-                    day: r.day,
-                    program: 'bulk_rescue' as const,
-                    totalPounds: Math.round(Number(r.totalPounds ?? 0)),
-                    destination:
-                        r.destination?.trim() || scopedDestinationName || partnerHouseholdId18,
-                })),
-                ...jeRows.map(r => ({
-                    day: r.day,
-                    program: 'just_eats' as const,
-                    totalPounds: Math.round(Number(r.totalPounds ?? 0)),
+            const destinationForRow =
+                brRows[0]?.destination?.trim() || scopedDestinationName || destLabel || hh;
+
+            const mergedBr: DeliveryOut[] = [];
+            for (const r of brRows) {
+                const day = r.day;
+                const extra = orphanByDay.get(day) ?? 0;
+                if (extra) orphanByDay.delete(day);
+                mergedBr.push({
+                    id: `${day}|${hh}-br|bulk_rescue`,
+                    date: `${day}T00:00:00.000Z`,
+                    totalPounds: Math.round(Number(r.totalPounds ?? 0)) + extra,
+                    destination: r.destination?.trim() || destinationForRow,
+                    householdId18: hh,
+                    program: 'bulk_rescue',
+                });
+            }
+            for (const [day, lbs] of orphanByDay) {
+                if (lbs <= 0) continue;
+                mergedBr.push({
+                    id: `${day}|${hh}-orphan|bulk_rescue`,
+                    date: `${day}T00:00:00.000Z`,
+                    totalPounds: lbs,
                     destination: destinationForRow,
-                })),
-            ]
-                .sort((a, b) => (a.day < b.day ? 1 : a.day > b.day ? -1 : 0))
-                .slice(0, 10);
+                    householdId18: hh,
+                    program: 'bulk_rescue',
+                });
+            }
+
+            const jeOut: DeliveryOut[] = jeRows.map(r => ({
+                id: `${r.day}|${hh}|just_eats`,
+                date: `${r.day}T00:00:00.000Z`,
+                totalPounds: Math.round(Number(r.totalPounds ?? 0)),
+                destination: destinationForRow,
+                householdId18: hh,
+                program: 'just_eats',
+            }));
+
+            const merged = mergeDeliveryBuckets([...mergedBr, ...jeOut]).sort((a, b) =>
+                a.date < b.date ? 1 : a.date > b.date ? -1 : 0
+            );
 
             return NextResponse.json({
-                deliveries: merged.map(r => ({
-                    id: `${r.day}|${partnerHouseholdId18}|${r.program}`,
-                    date: `${r.day}T00:00:00.000Z`,
+                deliveries: merged.slice(0, 10).map(r => ({
+                    id: r.id,
+                    date: r.date,
                     totalPounds: r.totalPounds,
                     destination: r.destination,
-                    householdId18: partnerHouseholdId18,
+                    householdId18: r.householdId18,
                     program: r.program,
                 })),
             });
         }
+
         type DeliveryRow = {
             day: string;
             destination: string | null;
@@ -142,54 +320,84 @@ export async function GET(request: NextRequest) {
             householdId18: string | null;
             program: string;
         };
-        const rows = await prisma.$queryRaw<DeliveryRow[]>`
-            SELECT
-                TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
-                COALESCE(pt."organizationName", d."householdName") AS "destination",
-                d."householdId18" AS "householdId18",
-                SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "totalPounds",
-                'bulk_rescue'::text AS "program"
-            FROM "AllInventoryTransactions" t
-            INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
-            INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
-            LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
-            WHERE d."date" >= ${range.start}
-              AND d."date" <= ${range.end}
-            GROUP BY DATE_TRUNC('day', d."date"), d."householdId18", COALESCE(pt."organizationName", d."householdName")
-            HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
 
-            UNION ALL
+        const [joinedRows, orphanGrp, jeGrp] = await Promise.all([
+            prisma.$queryRaw<DeliveryRow[]>`
+                SELECT
+                    TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
+                    COALESCE(pt."organizationName", d."householdName") AS "destination",
+                    d."householdId18" AS "householdId18",
+                    SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "totalPounds",
+                    'bulk_rescue'::text AS "program"
+                FROM "AllInventoryTransactions" t
+                INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+                INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
+                LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                WHERE d."date" >= ${range.start}
+                  AND d."date" <= ${range.end}
+                GROUP BY DATE_TRUNC('day', d."date"), d."householdId18", COALESCE(pt."organizationName", d."householdName"), 'bulk_rescue'::text
+                HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
+            `,
+            prisma.$queryRaw<DeliveryRow[]>`
+                SELECT
+                    TO_CHAR(DATE_TRUNC('day', t."date"), 'YYYY-MM-DD') AS "day",
+                    TRIM(t."destination") AS "destination",
+                    NULL::text AS "householdId18",
+                    SUM(${inventoryTxPoundsSql()}) AS "totalPounds",
+                    'bulk_rescue'::text AS "program"
+                FROM "AllInventoryTransactions" t
+                WHERE t."date" >= ${range.start}
+                  AND t."date" <= ${range.end}
+                  AND ${distributionInventoryTypeCondition}
+                  AND ${orphanInventoryCondition}
+                  AND TRIM(COALESCE(t."destination", '')) <> ''
+                GROUP BY DATE_TRUNC('day', t."date"), TRIM(t."destination"), 'bulk_rescue'::text
+                HAVING SUM(${inventoryTxPoundsSql()}) > 0
+            `,
+            prisma.$queryRaw<DeliveryRow[]>`
+                SELECT
+                    TO_CHAR(DATE_TRUNC('day', t."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+                    COALESCE(pt."organizationName", t."householdName") AS "destination",
+                    t."householdId" AS "householdId18",
+                    COUNT(*) * 25 as "totalPounds",
+                    'just_eats'::text AS "program"
+                FROM "JustEatsBoxes" t
+                LEFT JOIN "Partner" pt ON pt."householdId18" = t."householdId"
+                WHERE t."pantryVisitDateTime" >= ${range.start}
+                  AND t."pantryVisitDateTime" <= ${range.end}
+                GROUP BY DATE_TRUNC('day', t."pantryVisitDateTime"), t."householdId", COALESCE(pt."organizationName", t."householdName"), 'just_eats'::text
+                HAVING COUNT(*) * 25 > 0
+            `,
+        ]);
 
-            SELECT
-                TO_CHAR(DATE_TRUNC('day', t."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
-                COALESCE(pt."organizationName", t."householdName") AS "destination",
-                t."householdId" AS "householdId18",
-                COUNT(*) * 25 as "totalPounds",
-                'just_eats'::text AS "program"
-            FROM "JustEatsBoxes" t
-            LEFT JOIN "Partner" pt ON pt."householdId18" = t."householdId"
-            WHERE t."pantryVisitDateTime" >= ${range.start}
-              AND t."pantryVisitDateTime" <= ${range.end}
-            GROUP BY DATE_TRUNC('day', t."pantryVisitDateTime"), t."householdId", COALESCE(pt."organizationName", t."householdName")
+        const combined: DeliveryOut[] = [...joinedRows, ...orphanGrp, ...jeGrp].map(r => {
+            const day = r.day;
+            const destination = r.destination ?? null;
+            const householdId18 = r.householdId18 ?? null;
+            const program = r.program === 'just_eats' ? 'just_eats' : 'bulk_rescue';
+            return {
+                id: `${day}|${householdId18 ?? normalizeDestinationName(destination ?? '')}|${program}`,
+                date: `${day}T00:00:00.000Z`,
+                totalPounds: Math.round(Number(r.totalPounds ?? 0)),
+                destination: destination ?? '',
+                householdId18,
+                program,
+            };
+        });
 
-            ORDER BY "day" DESC
-            LIMIT 10
-        `;
+        const mergedAll = mergeDeliveryBuckets(combined).sort((a, b) =>
+            a.date < b.date ? 1 : a.date > b.date ? -1 : 0
+        );
 
         return NextResponse.json({
-            deliveries: rows.map(r => {
-                const day = r.day;
-                const destination = r.destination ?? null;
-                const householdId18 = r.householdId18 ?? null;
-                return {
-                    id: `${day}|${householdId18 ?? destination ?? ''}|${r.program}`,
-                    date: `${day}T00:00:00.000Z`,
-                    totalPounds: Math.round(Number(r.totalPounds ?? 0)),
-                    destination,
-                    householdId18,
-                    program: r.program,
-                };
-            }),
+            deliveries: mergedAll.slice(0, 10).map(r => ({
+                id: r.id,
+                date: r.date,
+                totalPounds: r.totalPounds,
+                destination: r.destination || null,
+                householdId18: r.householdId18,
+                program: r.program,
+            })),
         });
     } catch (err: unknown) {
         console.error('Overview deliveries error:', err);

--- a/src/app/api/overview/food-types/route.ts
+++ b/src/app/api/overview/food-types/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import prisma from '~/lib/prisma';
+import type { OverviewScope } from '~/lib/overviewAccess';
+import {
+    getOverviewScope,
+    overviewScopeErrorResponse,
+    scopeEffectiveHouseholdId18,
+    scopeOrganizationNameFilter,
+} from '~/lib/overviewAccess';
 import {
     COMPOSITION_EMPTY_SEGMENT_COLOR,
     PROCESSING_OVERVIEW_COLOR_BY_LABEL,
@@ -8,10 +15,10 @@ import {
     type FoodTypeCompositionEntry,
 } from '~/lib/chartCompositionColors';
 import {
-    getOverviewScope,
-    overviewScopeErrorResponse,
-    scopeToPartnerHouseholdId18,
-} from '~/lib/overviewAccess';
+    distributionInventoryTypeCondition,
+    inventoryTxPoundsSql,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 
 function parseDateRange(searchParams: URLSearchParams): { start: Date; end: Date } | null {
     const startParam = searchParams.get('start');
@@ -45,9 +52,16 @@ function getDefaultRange(): { start: Date; end: Date } {
     return { start, end };
 }
 
+function destinationLabel(scope: OverviewScope): string {
+    if (scope.kind === 'partner' || scope.kind === 'admin') {
+        return scope.destination?.trim() ?? '';
+    }
+    return '';
+}
+
 /**
  * GET /api/overview/food-types?start=...&end=...&destination=...
- * Returns composition (lbs) by product type and minimally processed flag.
+ * Composition for bulk & recovery includes orphan distribution-only inventory rows.
  */
 export async function GET(request: NextRequest) {
     try {
@@ -60,42 +74,93 @@ export async function GET(request: NextRequest) {
         if (scopeErr) return scopeErr;
 
         const range = parseDateRange(searchParams) ?? getDefaultRange();
-        const partnerHouseholdId18 = scopeToPartnerHouseholdId18(scope);
+        const partnerHouseholdId18 = scopeEffectiveHouseholdId18(scope);
+        const orgNameOnly = scopeOrganizationNameFilter(scope);
+        const destLabel = destinationLabel(scope);
 
-        const partnerClause = partnerHouseholdId18
+        const joinedPartnerClause = partnerHouseholdId18
             ? Prisma.sql`AND d."householdId18" = ${partnerHouseholdId18}`
             : Prisma.empty;
 
+        const joinedNameClause = orgNameOnly
+            ? Prisma.sql`AND LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))`
+            : Prisma.empty;
+
+        const orphanDisabled = Boolean(partnerHouseholdId18) && destLabel.length === 0;
+        const orphanScopeClause = orphanDisabled
+            ? Prisma.sql`AND FALSE`
+            : orgNameOnly != null
+              ? Prisma.sql`AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${orgNameOnly}))`
+              : partnerHouseholdId18 && destLabel.length > 0
+                ? Prisma.sql`AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${destLabel}))`
+                : Prisma.empty;
+
         type ProductTypeRow = { productType: string | null; pounds: number | null };
         const foodTypeGrouped = await prisma.$queryRaw<ProductTypeRow[]>`
-            SELECT
-                t."productType" AS "productType",
-                SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
-            FROM "AllInventoryTransactions" t
-            INNER JOIN "AllPackagesByItem" p
-                ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
-            INNER JOIN "AllProductPackageDestinations" d
-                ON d."productPackageId18" = p."productPackageId18"
-            WHERE d."date" >= ${range.start}
-              AND d."date" <= ${range.end}
-              ${partnerClause}
-            GROUP BY t."productType"
+            SELECT "productType", SUM("pounds") AS "pounds" FROM (
+                SELECT
+                    t."productType" AS "productType",
+                    SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
+                FROM "AllInventoryTransactions" t
+                INNER JOIN "AllPackagesByItem" p
+                    ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+                INNER JOIN "AllProductPackageDestinations" d
+                    ON d."productPackageId18" = p."productPackageId18"
+                LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                WHERE d."date" >= ${range.start}
+                  AND d."date" <= ${range.end}
+                  ${joinedPartnerClause}
+                  ${joinedNameClause}
+                GROUP BY t."productType"
+
+                UNION ALL
+
+                SELECT
+                    t."productType" AS "productType",
+                    SUM(${inventoryTxPoundsSql()}) AS "pounds"
+                FROM "AllInventoryTransactions" t
+                WHERE t."date" >= ${range.start}
+                  AND t."date" <= ${range.end}
+                  AND ${distributionInventoryTypeCondition}
+                  AND ${orphanInventoryCondition}
+                  ${orphanScopeClause}
+                GROUP BY t."productType"
+            ) sub
+            GROUP BY "productType"
         `;
 
         type ProcessingRow = { minimallyProcessedFood: boolean | null; pounds: number | null };
         const processingGrouped = await prisma.$queryRaw<ProcessingRow[]>`
-            SELECT
-                t."minimallyProcessedFood" AS "minimallyProcessedFood",
-                SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
-            FROM "AllInventoryTransactions" t
-            INNER JOIN "AllPackagesByItem" p
-                ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
-            INNER JOIN "AllProductPackageDestinations" d
-                ON d."productPackageId18" = p."productPackageId18"
-            WHERE d."date" >= ${range.start}
-              AND d."date" <= ${range.end}
-              ${partnerClause}
-            GROUP BY t."minimallyProcessedFood"
+            SELECT "minimallyProcessedFood", SUM("pounds") AS "pounds" FROM (
+                SELECT
+                    t."minimallyProcessedFood" AS "minimallyProcessedFood",
+                    SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
+                FROM "AllInventoryTransactions" t
+                INNER JOIN "AllPackagesByItem" p
+                    ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+                INNER JOIN "AllProductPackageDestinations" d
+                    ON d."productPackageId18" = p."productPackageId18"
+                LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                WHERE d."date" >= ${range.start}
+                  AND d."date" <= ${range.end}
+                  ${joinedPartnerClause}
+                  ${joinedNameClause}
+                GROUP BY t."minimallyProcessedFood"
+
+                UNION ALL
+
+                SELECT
+                    t."minimallyProcessedFood" AS "minimallyProcessedFood",
+                    SUM(${inventoryTxPoundsSql()}) AS "pounds"
+                FROM "AllInventoryTransactions" t
+                WHERE t."date" >= ${range.start}
+                  AND t."date" <= ${range.end}
+                  AND ${distributionInventoryTypeCondition}
+                  AND ${orphanInventoryCondition}
+                  ${orphanScopeClause}
+                GROUP BY t."minimallyProcessedFood"
+            ) sub
+            GROUP BY "minimallyProcessedFood"
         `;
 
         const foodTypes: FoodTypeCompositionEntry[] = foodTypeGrouped

--- a/src/app/api/overview/partners/route.ts
+++ b/src/app/api/overview/partners/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server';
 import prisma from '~/lib/prisma';
+import { normalizeDestinationName } from '~/lib/destinationNameFilter';
 import { getOverviewScope, overviewScopeErrorResponse } from '~/lib/overviewAccess';
+import type { PartnerOrgCard } from '@/types/partner';
 
 /**
  * GET /api/overview/partners
- * Admins: all distinct household names. Partners: only their org (for display; search is hidden in UI).
+ * Partner accounts: their org only. Admins: Clerk partners plus any distribution destinations
+ * seen in destination tables or inventory (without duplicating names that already map to a Partner).
  */
 export async function GET() {
     try {
@@ -16,7 +19,7 @@ export async function GET() {
             return NextResponse.json({
                 partners: [
                     {
-                        id: 1,
+                        id: `p-${scope.partnerHouseholdId18}`,
                         name: scope.destination,
                         householdId18: scope.partnerHouseholdId18,
                         location: '',
@@ -27,21 +30,71 @@ export async function GET() {
             });
         }
 
-        const partners = await prisma.partner.findMany({
-            select: { organizationName: true, householdId18: true },
-            orderBy: { organizationName: 'asc' },
-        });
+        const [partnerRows, destinationNameRows] = await Promise.all([
+            prisma.partner.findMany({
+                select: { organizationName: true, householdId18: true },
+                orderBy: { organizationName: 'asc' },
+            }),
+            prisma.$queryRaw<{ name: string | null }[]>`
+                SELECT DISTINCT TRIM(x.n) AS "name"
+                FROM (
+                    SELECT TRIM(d."householdName") AS n
+                    FROM "AllProductPackageDestinations" d
+                    WHERE TRIM(COALESCE(d."householdName", '')) <> ''
+
+                    UNION
+
+                    SELECT TRIM(j."householdName") AS n
+                    FROM "JustEatsBoxes" j
+                    WHERE TRIM(COALESCE(j."householdName", '')) <> ''
+
+                    UNION
+
+                    SELECT TRIM(t."destination") AS n
+                    FROM "AllInventoryTransactions" t
+                    WHERE TRIM(COALESCE(t."destination", '')) <> ''
+                      AND LOWER(TRIM(COALESCE(t."inventoryType", ''))) = 'distribution'
+                ) x
+                WHERE TRIM(COALESCE(x.n, '')) <> ''
+                ORDER BY 1 ASC
+            `,
+        ]);
+
+        const byNormalized = new Map<string, PartnerOrgCard>();
+
+        for (const partner of partnerRows) {
+            const name = partner.organizationName?.trim() ?? '';
+            if (!name) continue;
+            const key = normalizeDestinationName(name);
+            byNormalized.set(key, {
+                id: `p-${partner.householdId18}`,
+                name,
+                householdId18: partner.householdId18,
+                location: '',
+                type: 'Partner',
+            });
+        }
+
+        for (const row of destinationNameRows) {
+            const name = row.name?.trim() ?? '';
+            if (!name) continue;
+            const key = normalizeDestinationName(name);
+            if (byNormalized.has(key)) continue;
+            byNormalized.set(key, {
+                id: `d-${key}`,
+                name,
+                householdId18: null,
+                location: '',
+                type: 'Destination',
+            });
+        }
+
+        const partners = [...byNormalized.values()].sort((a, b) =>
+            a.name.localeCompare(b.name, undefined, { sensitivity: 'base', numeric: true })
+        );
 
         return NextResponse.json({
-            partners: partners
-                .map((partner, index) => ({
-                    id: index + 1,
-                    name: partner.organizationName?.trim() ?? '',
-                    householdId18: partner.householdId18,
-                    location: '',
-                    type: 'Partner',
-                }))
-                .filter(partner => partner.name),
+            partners,
             partnerDashboard: false,
         });
     } catch (err: unknown) {

--- a/src/app/api/overview/partners/route.ts
+++ b/src/app/api/overview/partners/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from 'next/server';
 import prisma from '~/lib/prisma';
 import { normalizeDestinationName } from '~/lib/destinationNameFilter';
 import { getOverviewScope, overviewScopeErrorResponse } from '~/lib/overviewAccess';
+import {
+    distributionInventoryTypeCondition,
+    inventoryTxPoundsSql,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 import type { PartnerOrgCard } from '@/types/partner';
 
 /**
@@ -36,31 +41,60 @@ export async function GET() {
                 orderBy: { organizationName: 'asc' },
             }),
             prisma.$queryRaw<{ name: string | null }[]>`
-                SELECT DISTINCT TRIM(x.n) AS "name"
-                FROM (
-                    SELECT TRIM(d."householdName") AS n
-                    FROM "AllProductPackageDestinations" d
+                WITH valid_joined AS (
+                    SELECT
+                        TRIM(COALESCE(d."householdName", '')) AS name,
+                        SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS lbs
+                    FROM "AllInventoryTransactions" t
+                    INNER JOIN "AllPackagesByItem" p
+                        ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
+                    INNER JOIN "AllProductPackageDestinations" d
+                        ON d."productPackageId18" = p."productPackageId18"
                     WHERE TRIM(COALESCE(d."householdName", '')) <> ''
-
-                    UNION
-
-                    SELECT TRIM(j."householdName") AS n
-                    FROM "JustEatsBoxes" j
-                    WHERE TRIM(COALESCE(j."householdName", '')) <> ''
-
-                    UNION
-
-                    SELECT TRIM(t."destination") AS n
+                    GROUP BY TRIM(COALESCE(d."householdName", ''))
+                    HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
+                ),
+                valid_orphan AS (
+                    SELECT
+                        TRIM(t."destination") AS name,
+                        SUM(${inventoryTxPoundsSql()}) AS lbs
                     FROM "AllInventoryTransactions" t
                     WHERE TRIM(COALESCE(t."destination", '')) <> ''
-                      AND LOWER(TRIM(COALESCE(t."inventoryType", ''))) = 'distribution'
-                ) x
-                WHERE TRIM(COALESCE(x.n, '')) <> ''
+                      AND ${distributionInventoryTypeCondition}
+                      AND ${orphanInventoryCondition}
+                    GROUP BY TRIM(t."destination")
+                    HAVING SUM(${inventoryTxPoundsSql()}) > 0
+                ),
+                valid_just_eats AS (
+                    SELECT
+                        TRIM(COALESCE(pt."organizationName", j."householdName")) AS name,
+                        SUM(COALESCE(j."numberDistributed", 1)) AS boxes
+                    FROM "JustEatsBoxes" j
+                    LEFT JOIN "Partner" pt ON pt."householdId18" = j."householdId"
+                    WHERE TRIM(COALESCE(j."householdName", '')) <> ''
+                    GROUP BY TRIM(COALESCE(pt."organizationName", j."householdName"))
+                    HAVING SUM(COALESCE(j."numberDistributed", 1)) > 0
+                )
+                SELECT DISTINCT TRIM(name) AS "name"
+                FROM (
+                    SELECT name FROM valid_joined
+                    UNION
+                    SELECT name FROM valid_orphan
+                    UNION
+                    SELECT name FROM valid_just_eats
+                ) v
+                WHERE TRIM(COALESCE(name, '')) <> ''
                 ORDER BY 1 ASC
             `,
         ]);
 
         const byNormalized = new Map<string, PartnerOrgCard>();
+        const validNormalizedNames = new Set(
+            destinationNameRows
+                .map(row => row.name?.trim() ?? '')
+                .filter(Boolean)
+                .map(name => normalizeDestinationName(name))
+        );
 
         for (const partner of partnerRows) {
             const name = partner.organizationName?.trim() ?? '';

--- a/src/app/api/overview/pounds-by-month/route.ts
+++ b/src/app/api/overview/pounds-by-month/route.ts
@@ -84,7 +84,7 @@ async function fetchBulkDaily(
             LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
             WHERE d."date" >= ${range.start}
               AND d."date" <= ${range.end}
-              AND LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))
+              AND LOWER(TRIM(d."householdName")) = LOWER(TRIM(${orgNameOnly}))
             GROUP BY DATE_TRUNC('day', d."date")
             HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
             ORDER BY DATE_TRUNC('day', d."date") ASC
@@ -193,9 +193,26 @@ async function fetchJustEatsDaily(
                 TO_CHAR(DATE_TRUNC('day', j."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
                 COUNT(*) * 25 AS "pounds"
             FROM "JustEatsBoxes" j
+            LEFT JOIN "Partner" pt ON pt."householdId18" = j."householdId"
             WHERE j."pantryVisitDateTime" >= ${range.start}
               AND j."pantryVisitDateTime" <= ${range.end}
               AND LOWER(TRIM(j."householdName")) = LOWER(TRIM(${orgNameOnly}))
+              AND EXISTS (
+                  SELECT 1
+                  FROM (
+                      SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                      FROM "AllProductPackageDestinations" d2
+                      WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                      UNION
+
+                      SELECT LOWER(TRIM(t2."destination")) AS org_name
+                      FROM "AllInventoryTransactions" t2
+                      WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                        AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+                  ) valid_orgs
+                  WHERE valid_orgs.org_name = LOWER(TRIM(j."householdName"))
+              )
             GROUP BY DATE_TRUNC('day', j."pantryVisitDateTime")
             ORDER BY DATE_TRUNC('day', j."pantryVisitDateTime") ASC
         `;
@@ -208,9 +225,26 @@ async function fetchJustEatsDaily(
                 TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
                 COUNT(*) * 25 AS "pounds"
             FROM "JustEatsBoxes" d
+            LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId"
             WHERE d."householdId" = ${hh}
               AND d."pantryVisitDateTime" >= ${range.start}
               AND d."pantryVisitDateTime" <= ${range.end}
+              AND EXISTS (
+                  SELECT 1
+                  FROM (
+                      SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                      FROM "AllProductPackageDestinations" d2
+                      WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                      UNION
+
+                      SELECT LOWER(TRIM(t2."destination")) AS org_name
+                      FROM "AllInventoryTransactions" t2
+                      WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                        AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+                  ) valid_orgs
+                  WHERE valid_orgs.org_name = LOWER(TRIM(d."householdName"))
+              )
             GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
             ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
         `;
@@ -221,8 +255,26 @@ async function fetchJustEatsDaily(
             TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
             COUNT(*) * 25 AS "pounds"
         FROM "JustEatsBoxes" d
+        LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId"
         WHERE d."pantryVisitDateTime" >= ${range.start}
           AND d."pantryVisitDateTime" <= ${range.end}
+          AND TRIM(COALESCE(d."householdName", '')) <> ''
+          AND EXISTS (
+              SELECT 1
+              FROM (
+                  SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                  FROM "AllProductPackageDestinations" d2
+                  WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                  UNION
+
+                  SELECT LOWER(TRIM(t2."destination")) AS org_name
+                  FROM "AllInventoryTransactions" t2
+                  WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                    AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+              ) valid_orgs
+              WHERE valid_orgs.org_name = LOWER(TRIM(d."householdName"))
+          )
         GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
         ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
     `;

--- a/src/app/api/overview/pounds-by-month/route.ts
+++ b/src/app/api/overview/pounds-by-month/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '~/lib/prisma';
+import type { OverviewScope } from '~/lib/overviewAccess';
 import {
     getOverviewScope,
     overviewScopeErrorResponse,
-    scopeToPartnerHouseholdId18,
+    scopeEffectiveHouseholdId18,
+    scopeOrganizationNameFilter,
 } from '~/lib/overviewAccess';
+import {
+    distributionInventoryTypeCondition,
+    inventoryTxPoundsSql,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 
 const MONTH_NAMES = [
     'Jan',
@@ -53,6 +60,183 @@ function getDefaultRange(): { start: Date; end: Date } {
     return { start, end };
 }
 
+function destinationLabel(scope: OverviewScope): string {
+    if (scope.kind === 'partner' || scope.kind === 'admin') {
+        return scope.destination?.trim() ?? '';
+    }
+    return '';
+}
+
+type DailyRow = { day: string; pounds: number | null };
+
+async function fetchBulkDaily(
+    range: { start: Date; end: Date },
+    scope: OverviewScope
+): Promise<DailyRow[]> {
+    const orgNameOnly = scopeOrganizationNameFilter(scope);
+    if (orgNameOnly) {
+        return prisma.$queryRaw<DailyRow[]>`
+            SELECT
+                TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
+                SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
+            FROM "AllProductPackageDestinations" d
+            LEFT JOIN "AllPackagesByItem" p ON p."productPackageId18" = d."productPackageId18"
+            LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+            WHERE d."date" >= ${range.start}
+              AND d."date" <= ${range.end}
+              AND LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))
+            GROUP BY DATE_TRUNC('day', d."date")
+            HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
+            ORDER BY DATE_TRUNC('day', d."date") ASC
+        `;
+    }
+
+    const hh = scopeEffectiveHouseholdId18(scope);
+    if (hh) {
+        return prisma.$queryRaw<DailyRow[]>`
+            SELECT
+                TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
+                SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
+            FROM "AllProductPackageDestinations" d
+            LEFT JOIN "AllPackagesByItem" p ON p."productPackageId18" = d."productPackageId18"
+            WHERE d."householdId18" = ${hh}
+              AND d."date" >= ${range.start}
+              AND d."date" <= ${range.end}
+            GROUP BY DATE_TRUNC('day', d."date")
+            HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
+            ORDER BY DATE_TRUNC('day', d."date") ASC
+        `;
+    }
+
+    return prisma.$queryRaw<DailyRow[]>`
+        SELECT
+            TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
+            SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
+        FROM "AllProductPackageDestinations" d
+        LEFT JOIN "AllPackagesByItem" p ON p."productPackageId18" = d."productPackageId18"
+        WHERE d."date" >= ${range.start}
+          AND d."date" <= ${range.end}
+        GROUP BY DATE_TRUNC('day', d."date")
+        HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
+        ORDER BY DATE_TRUNC('day', d."date") ASC
+    `;
+}
+
+async function fetchOrphanDaily(
+    range: { start: Date; end: Date },
+    scope: OverviewScope
+): Promise<DailyRow[]> {
+    const orgNameOnly = scopeOrganizationNameFilter(scope);
+    if (orgNameOnly) {
+        return prisma.$queryRaw<DailyRow[]>`
+            SELECT
+                TO_CHAR(DATE_TRUNC('day', t."date"), 'YYYY-MM-DD') AS "day",
+                SUM(${inventoryTxPoundsSql()}) AS "pounds"
+            FROM "AllInventoryTransactions" t
+            WHERE t."date" >= ${range.start}
+              AND t."date" <= ${range.end}
+              AND ${distributionInventoryTypeCondition}
+              AND ${orphanInventoryCondition}
+              AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${orgNameOnly}))
+            GROUP BY DATE_TRUNC('day', t."date")
+            HAVING SUM(${inventoryTxPoundsSql()}) > 0
+            ORDER BY DATE_TRUNC('day', t."date") ASC
+        `;
+    }
+
+    const hh = scopeEffectiveHouseholdId18(scope);
+    const destLabel = destinationLabel(scope);
+    if (hh && destLabel.length > 0) {
+        return prisma.$queryRaw<DailyRow[]>`
+            SELECT
+                TO_CHAR(DATE_TRUNC('day', t."date"), 'YYYY-MM-DD') AS "day",
+                SUM(${inventoryTxPoundsSql()}) AS "pounds"
+            FROM "AllInventoryTransactions" t
+            WHERE t."date" >= ${range.start}
+              AND t."date" <= ${range.end}
+              AND ${distributionInventoryTypeCondition}
+              AND ${orphanInventoryCondition}
+              AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${destLabel}))
+            GROUP BY DATE_TRUNC('day', t."date")
+            HAVING SUM(${inventoryTxPoundsSql()}) > 0
+            ORDER BY DATE_TRUNC('day', t."date") ASC
+        `;
+    }
+    if (hh) {
+        return [];
+    }
+
+    return prisma.$queryRaw<DailyRow[]>`
+        SELECT
+            TO_CHAR(DATE_TRUNC('day', t."date"), 'YYYY-MM-DD') AS "day",
+            SUM(${inventoryTxPoundsSql()}) AS "pounds"
+        FROM "AllInventoryTransactions" t
+        WHERE t."date" >= ${range.start}
+          AND t."date" <= ${range.end}
+          AND ${distributionInventoryTypeCondition}
+          AND ${orphanInventoryCondition}
+          AND TRIM(COALESCE(t."destination", '')) <> ''
+        GROUP BY DATE_TRUNC('day', t."date")
+        HAVING SUM(${inventoryTxPoundsSql()}) > 0
+        ORDER BY DATE_TRUNC('day', t."date") ASC
+    `;
+}
+
+async function fetchJustEatsDaily(
+    range: { start: Date; end: Date },
+    scope: OverviewScope
+): Promise<DailyRow[]> {
+    const orgNameOnly = scopeOrganizationNameFilter(scope);
+    if (orgNameOnly) {
+        return prisma.$queryRaw<DailyRow[]>`
+            SELECT
+                TO_CHAR(DATE_TRUNC('day', j."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+                COUNT(*) * 25 AS "pounds"
+            FROM "JustEatsBoxes" j
+            WHERE j."pantryVisitDateTime" >= ${range.start}
+              AND j."pantryVisitDateTime" <= ${range.end}
+              AND LOWER(TRIM(j."householdName")) = LOWER(TRIM(${orgNameOnly}))
+            GROUP BY DATE_TRUNC('day', j."pantryVisitDateTime")
+            ORDER BY DATE_TRUNC('day', j."pantryVisitDateTime") ASC
+        `;
+    }
+
+    const hh = scopeEffectiveHouseholdId18(scope);
+    if (hh) {
+        return prisma.$queryRaw<DailyRow[]>`
+            SELECT
+                TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+                COUNT(*) * 25 AS "pounds"
+            FROM "JustEatsBoxes" d
+            WHERE d."householdId" = ${hh}
+              AND d."pantryVisitDateTime" >= ${range.start}
+              AND d."pantryVisitDateTime" <= ${range.end}
+            GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
+            ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
+        `;
+    }
+
+    return prisma.$queryRaw<DailyRow[]>`
+        SELECT
+            TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
+            COUNT(*) * 25 AS "pounds"
+        FROM "JustEatsBoxes" d
+        WHERE d."pantryVisitDateTime" >= ${range.start}
+          AND d."pantryVisitDateTime" <= ${range.end}
+        GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
+        ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
+    `;
+}
+
+function mergeDailyByDay(rows: DailyRow[]): DailyRow[] {
+    const map = new Map<string, number>();
+    for (const r of rows) {
+        const v = Number(r.pounds ?? 0);
+        map.set(r.day, (map.get(r.day) ?? 0) + v);
+    }
+    return [...map.entries()].map(([day, pounds]) => ({ day, pounds }));
+}
+
 export async function GET(request: NextRequest) {
     try {
         const searchParams = request.nextUrl.searchParams;
@@ -64,7 +248,14 @@ export async function GET(request: NextRequest) {
         if (scopeErr) return scopeErr;
 
         const range = parseDateRange(searchParams) ?? getDefaultRange();
-        const partnerHouseholdId18 = scopeToPartnerHouseholdId18(scope);
+
+        const [bulkJoined, orphanDaily, justEatsDailyRows] = await Promise.all([
+            fetchBulkDaily(range, scope),
+            fetchOrphanDaily(range, scope),
+            fetchJustEatsDaily(range, scope),
+        ]);
+
+        const dailyRows = mergeDailyByDay([...bulkJoined, ...orphanDaily]);
 
         const daysDiff = Math.ceil(
             (range.end.getTime() - range.start.getTime()) / (1000 * 60 * 60 * 24)
@@ -76,62 +267,8 @@ export async function GET(request: NextRequest) {
         const aggregateByYear = yearsDiff > 1;
         const aggregateByDay = daysDiff <= 30 && !aggregateByYear;
 
-        type DailyRow = { day: string; pounds: number | null };
-        const dailyRows = partnerHouseholdId18
-            ? await prisma.$queryRaw<DailyRow[]>`
-                SELECT
-                    TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
-                    SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
-                FROM "AllProductPackageDestinations" d
-                LEFT JOIN "AllPackagesByItem" p
-                    ON p."productPackageId18" = d."productPackageId18"
-                WHERE d."householdId18" = ${partnerHouseholdId18}
-                  AND d."date" >= ${range.start}
-                  AND d."date" <= ${range.end}
-                GROUP BY DATE_TRUNC('day', d."date")
-                HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
-                ORDER BY DATE_TRUNC('day', d."date") ASC
-            `
-            : await prisma.$queryRaw<DailyRow[]>`
-                SELECT
-                    TO_CHAR(DATE_TRUNC('day', d."date"), 'YYYY-MM-DD') AS "day",
-                    SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
-                FROM "AllProductPackageDestinations" d
-                LEFT JOIN "AllPackagesByItem" p
-                    ON p."productPackageId18" = d."productPackageId18"
-                WHERE d."date" >= ${range.start}
-                  AND d."date" <= ${range.end}
-                GROUP BY DATE_TRUNC('day', d."date")
-                HAVING SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) > 0
-                ORDER BY DATE_TRUNC('day', d."date") ASC
-            `;
-
-        const justEatsDailyRows = partnerHouseholdId18
-            ? await prisma.$queryRaw<DailyRow[]>`
-                SELECT
-                    TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
-                    COUNT(*) * 25 AS "pounds"
-                FROM "JustEatsBoxes" d
-                WHERE d."householdId" = ${partnerHouseholdId18}
-                  AND d."pantryVisitDateTime" >= ${range.start}
-                  AND d."pantryVisitDateTime" <= ${range.end}
-                GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
-                ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
-            `
-            : await prisma.$queryRaw<DailyRow[]>`
-                SELECT
-                    TO_CHAR(DATE_TRUNC('day', d."pantryVisitDateTime"), 'YYYY-MM-DD') AS "day",
-                    COUNT(*) * 25 AS "pounds"
-                FROM "JustEatsBoxes" d
-                WHERE d."pantryVisitDateTime" >= ${range.start}
-                  AND d."pantryVisitDateTime" <= ${range.end}
-                GROUP BY DATE_TRUNC('day', d."pantryVisitDateTime")
-                ORDER BY DATE_TRUNC('day', d."pantryVisitDateTime") ASC
-            `;
-
         const buckets: Record<string, number> = {};
 
-        // add data from AllPackagesByItem to an array
         for (const row of dailyRows) {
             const [yearStr, monthStr, dayStr] = row.day.split('-');
             const y = Number.parseInt(yearStr ?? '', 10);
@@ -150,7 +287,6 @@ export async function GET(request: NextRequest) {
             buckets[key] = (buckets[key] ?? 0) + weight;
         }
 
-        // add data from JustEatsBoxes to an existing array
         for (const row of justEatsDailyRows) {
             const [yearStr, monthStr, dayStr] = row.day.split('-');
             const y = Number.parseInt(yearStr ?? '', 10);
@@ -169,12 +305,10 @@ export async function GET(request: NextRequest) {
             buckets[key] = (buckets[key] ?? 0) + weight;
         }
 
-        // Build ordered list of all periods in range so chart shows only range span
         type Period = { month: string; order: number };
         const periodsInRange: Period[] = [];
 
         if (aggregateByYear) {
-            // Only show years that have data (earliest data year onward)
             const yearsWithData = Object.keys(buckets)
                 .filter(k => /^\d{4}$/.test(k))
                 .map(y => parseInt(y, 10))

--- a/src/app/api/overview/stats/route.ts
+++ b/src/app/api/overview/stats/route.ts
@@ -79,7 +79,7 @@ async function queryBulkAndRescueStats(
                 LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
                 WHERE d."date" >= ${range.start}
                   AND d."date" <= ${range.end}
-                  AND LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))
+                  AND LOWER(TRIM(d."householdName")) = LOWER(TRIM(${orgNameOnly}))
                 GROUP BY DATE_TRUNC('day', d."date")
             ),
             orphan AS (
@@ -230,9 +230,26 @@ async function queryJustEatsStats(
                 (COALESCE(SUM(COALESCE(j."numberDistributed", 1)), 0) * 25)::float AS "justEatsPoundsDelivered",
                 COUNT(*)::int AS "justEatsTotalDeliveries"
             FROM "JustEatsBoxes" j
+            LEFT JOIN "Partner" pt ON pt."householdId18" = j."householdId"
             WHERE j."pantryVisitDateTime" >= ${range.start}
               AND j."pantryVisitDateTime" <= ${range.end}
               AND LOWER(TRIM(j."householdName")) = LOWER(TRIM(${orgNameOnly}))
+              AND EXISTS (
+                  SELECT 1
+                  FROM (
+                      SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                      FROM "AllProductPackageDestinations" d2
+                      WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                      UNION
+
+                      SELECT LOWER(TRIM(t2."destination")) AS org_name
+                      FROM "AllInventoryTransactions" t2
+                      WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                        AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+                  ) valid_orgs
+                  WHERE valid_orgs.org_name = LOWER(TRIM(j."householdName"))
+              )
         `;
         return rows[0] ?? { justEatsPoundsDelivered: 0, justEatsTotalDeliveries: 0 };
     }
@@ -244,9 +261,26 @@ async function queryJustEatsStats(
                 (COALESCE(SUM(COALESCE(j."numberDistributed", 1)), 0) * 25)::float AS "justEatsPoundsDelivered",
                 COUNT(*)::int AS "justEatsTotalDeliveries"
             FROM "JustEatsBoxes" j
+            LEFT JOIN "Partner" pt ON pt."householdId18" = j."householdId"
             WHERE j."householdId" = ${hh}
               AND j."pantryVisitDateTime" >= ${range.start}
               AND j."pantryVisitDateTime" <= ${range.end}
+              AND EXISTS (
+                  SELECT 1
+                  FROM (
+                      SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                      FROM "AllProductPackageDestinations" d2
+                      WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                      UNION
+
+                      SELECT LOWER(TRIM(t2."destination")) AS org_name
+                      FROM "AllInventoryTransactions" t2
+                      WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                        AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+                  ) valid_orgs
+                  WHERE valid_orgs.org_name = LOWER(TRIM(j."householdName"))
+              )
         `;
         return rows[0] ?? { justEatsPoundsDelivered: 0, justEatsTotalDeliveries: 0 };
     }
@@ -256,8 +290,26 @@ async function queryJustEatsStats(
             (COALESCE(SUM(COALESCE(j."numberDistributed", 1)), 0) * 25)::float AS "justEatsPoundsDelivered",
             COUNT(*)::int AS "justEatsTotalDeliveries"
         FROM "JustEatsBoxes" j
+        LEFT JOIN "Partner" pt ON pt."householdId18" = j."householdId"
         WHERE j."pantryVisitDateTime" >= ${range.start}
           AND j."pantryVisitDateTime" <= ${range.end}
+          AND TRIM(COALESCE(j."householdName", '')) <> ''
+          AND EXISTS (
+              SELECT 1
+              FROM (
+                  SELECT LOWER(TRIM(d2."householdName")) AS org_name
+                  FROM "AllProductPackageDestinations" d2
+                  WHERE TRIM(COALESCE(d2."householdName", '')) <> ''
+
+                  UNION
+
+                  SELECT LOWER(TRIM(t2."destination")) AS org_name
+                  FROM "AllInventoryTransactions" t2
+                  WHERE TRIM(COALESCE(t2."destination", '')) <> ''
+                    AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+              ) valid_orgs
+              WHERE valid_orgs.org_name = LOWER(TRIM(j."householdName"))
+          )
     `;
     return rows[0] ?? { justEatsPoundsDelivered: 0, justEatsTotalDeliveries: 0 };
 }

--- a/src/app/api/overview/stats/route.ts
+++ b/src/app/api/overview/stats/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '~/lib/prisma';
+import type { OverviewScope } from '~/lib/overviewAccess';
 import {
     getOverviewScope,
     overviewScopeErrorResponse,
-    scopeToPartnerHouseholdId18,
+    scopeEffectiveHouseholdId18,
+    scopeOrganizationNameFilter,
 } from '~/lib/overviewAccess';
+import {
+    distributionInventoryTypeCondition,
+    inventoryTxPoundsSql,
+    orphanInventoryCondition,
+} from '~/lib/inventoryDistributionSql';
 
 function parseDateRange(searchParams: URLSearchParams): { start: Date; end: Date } | null {
     const startParam = searchParams.get('start');
@@ -48,23 +55,55 @@ type JustEatsStatsRow = {
     justEatsTotalDeliveries: number;
 };
 
+function destinationLabel(scope: OverviewScope): string {
+    if (scope.kind === 'partner' || scope.kind === 'admin') {
+        return scope.destination?.trim() ?? '';
+    }
+    return '';
+}
+
 async function queryBulkAndRescueStats(
     range: { start: Date; end: Date },
-    partnerHouseholdId18: string | undefined
+    scope: OverviewScope
 ): Promise<BulkRescueStatsRow> {
-    if (partnerHouseholdId18) {
+    const orgNameOnly = scopeOrganizationNameFilter(scope);
+    if (orgNameOnly) {
         const rows = await prisma.$queryRaw<BulkRescueStatsRow[]>`
-            WITH per_day AS (
+            WITH joined AS (
                 SELECT
                     DATE_TRUNC('day', d."date") AS day_bucket,
                     SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS day_pounds
                 FROM "AllProductPackageDestinations" d
                 LEFT JOIN "AllPackagesByItem" p
                     ON p."productPackageId18" = d."productPackageId18"
-                WHERE d."householdId18" = ${partnerHouseholdId18}
-                  AND d."date" >= ${range.start}
+                LEFT JOIN "Partner" pt ON pt."householdId18" = d."householdId18"
+                WHERE d."date" >= ${range.start}
                   AND d."date" <= ${range.end}
+                  AND LOWER(TRIM(COALESCE(pt."organizationName", d."householdName"))) = LOWER(TRIM(${orgNameOnly}))
                 GROUP BY DATE_TRUNC('day', d."date")
+            ),
+            orphan AS (
+                SELECT
+                    DATE_TRUNC('day', t."date") AS day_bucket,
+                    SUM(${inventoryTxPoundsSql()}) AS day_pounds
+                FROM "AllInventoryTransactions" t
+                WHERE t."date" >= ${range.start}
+                  AND t."date" <= ${range.end}
+                  AND ${distributionInventoryTypeCondition}
+                  AND ${orphanInventoryCondition}
+                  AND TRIM(COALESCE(t."destination", '')) <> ''
+                  AND LOWER(TRIM(t."destination")) = LOWER(TRIM(${orgNameOnly}))
+                GROUP BY DATE_TRUNC('day', t."date")
+            ),
+            merged AS (
+                SELECT day_bucket, day_pounds FROM joined
+                UNION ALL
+                SELECT day_bucket, day_pounds FROM orphan
+            ),
+            per_day AS (
+                SELECT day_bucket, SUM(day_pounds) AS day_pounds
+                FROM merged
+                GROUP BY day_bucket
             )
             SELECT
                 COALESCE(SUM(day_pounds) FILTER (WHERE day_pounds > 0), 0) AS "totalPoundsDelivered",
@@ -73,8 +112,76 @@ async function queryBulkAndRescueStats(
         `;
         return rows[0] ?? { totalPoundsDelivered: 0, deliveriesCompleted: 0 };
     }
+
+    const hh = scopeEffectiveHouseholdId18(scope);
+
+    if (hh) {
+        const destLabel = destinationLabel(scope);
+        const rows =
+            destLabel.length > 0
+                ? await prisma.$queryRaw<BulkRescueStatsRow[]>`
+                    WITH joined AS (
+                        SELECT
+                            DATE_TRUNC('day', d."date") AS day_bucket,
+                            SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS day_pounds
+                        FROM "AllProductPackageDestinations" d
+                        LEFT JOIN "AllPackagesByItem" p
+                            ON p."productPackageId18" = d."productPackageId18"
+                        WHERE d."householdId18" = ${hh}
+                          AND d."date" >= ${range.start}
+                          AND d."date" <= ${range.end}
+                        GROUP BY DATE_TRUNC('day', d."date")
+                    ),
+                    orphan AS (
+                        SELECT
+                            DATE_TRUNC('day', t."date") AS day_bucket,
+                            SUM(${inventoryTxPoundsSql()}) AS day_pounds
+                        FROM "AllInventoryTransactions" t
+                        WHERE t."date" >= ${range.start}
+                          AND t."date" <= ${range.end}
+                          AND ${distributionInventoryTypeCondition}
+                          AND ${orphanInventoryCondition}
+                          AND LOWER(TRIM(COALESCE(t."destination", ''))) = LOWER(TRIM(${destLabel}))
+                        GROUP BY DATE_TRUNC('day', t."date")
+                    ),
+                    merged AS (
+                        SELECT day_bucket, day_pounds FROM joined
+                        UNION ALL
+                        SELECT day_bucket, day_pounds FROM orphan
+                    ),
+                    per_day AS (
+                        SELECT day_bucket, SUM(day_pounds) AS day_pounds
+                        FROM merged
+                        GROUP BY day_bucket
+                    )
+                    SELECT
+                        COALESCE(SUM(day_pounds) FILTER (WHERE day_pounds > 0), 0) AS "totalPoundsDelivered",
+                        COUNT(*) FILTER (WHERE day_pounds > 0)::int AS "deliveriesCompleted"
+                    FROM per_day
+                `
+                : await prisma.$queryRaw<BulkRescueStatsRow[]>`
+                    WITH per_day AS (
+                        SELECT
+                            DATE_TRUNC('day', d."date") AS day_bucket,
+                            SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS day_pounds
+                        FROM "AllProductPackageDestinations" d
+                        LEFT JOIN "AllPackagesByItem" p
+                            ON p."productPackageId18" = d."productPackageId18"
+                        WHERE d."householdId18" = ${hh}
+                          AND d."date" >= ${range.start}
+                          AND d."date" <= ${range.end}
+                        GROUP BY DATE_TRUNC('day', d."date")
+                    )
+                    SELECT
+                        COALESCE(SUM(day_pounds) FILTER (WHERE day_pounds > 0), 0) AS "totalPoundsDelivered",
+                        COUNT(*) FILTER (WHERE day_pounds > 0)::int AS "deliveriesCompleted"
+                    FROM per_day
+                `;
+        return rows[0] ?? { totalPoundsDelivered: 0, deliveriesCompleted: 0 };
+    }
+
     const rows = await prisma.$queryRaw<BulkRescueStatsRow[]>`
-        WITH per_delivery AS (
+        WITH joined AS (
             SELECT
                 DATE_TRUNC('day', d."date") AS day_bucket,
                 d."householdId18" AS household_id,
@@ -85,31 +192,65 @@ async function queryBulkAndRescueStats(
             WHERE d."date" >= ${range.start}
               AND d."date" <= ${range.end}
             GROUP BY DATE_TRUNC('day', d."date"), d."householdId18"
+        ),
+        orphan AS (
+            SELECT
+                DATE_TRUNC('day', t."date") AS day_bucket,
+                TRIM(t."destination") AS dest_key,
+                SUM(${inventoryTxPoundsSql()}) AS delivery_pounds
+            FROM "AllInventoryTransactions" t
+            WHERE t."date" >= ${range.start}
+              AND t."date" <= ${range.end}
+              AND ${distributionInventoryTypeCondition}
+              AND ${orphanInventoryCondition}
+              AND TRIM(COALESCE(t."destination", '')) <> ''
+            GROUP BY DATE_TRUNC('day', t."date"), TRIM(t."destination")
+        ),
+        combined AS (
+            SELECT delivery_pounds FROM joined
+            UNION ALL
+            SELECT delivery_pounds FROM orphan
         )
         SELECT
             COALESCE(SUM(delivery_pounds) FILTER (WHERE delivery_pounds > 0), 0) AS "totalPoundsDelivered",
             COUNT(*) FILTER (WHERE delivery_pounds > 0)::int AS "deliveriesCompleted"
-        FROM per_delivery
+        FROM combined
     `;
     return rows[0] ?? { totalPoundsDelivered: 0, deliveriesCompleted: 0 };
 }
 
 async function queryJustEatsStats(
     range: { start: Date; end: Date },
-    partnerHouseholdId18: string | undefined
+    scope: OverviewScope
 ): Promise<JustEatsStatsRow> {
-    if (partnerHouseholdId18) {
+    const orgNameOnly = scopeOrganizationNameFilter(scope);
+    if (orgNameOnly) {
         const rows = await prisma.$queryRaw<JustEatsStatsRow[]>`
             SELECT
                 (COALESCE(SUM(COALESCE(j."numberDistributed", 1)), 0) * 25)::float AS "justEatsPoundsDelivered",
                 COUNT(*)::int AS "justEatsTotalDeliveries"
             FROM "JustEatsBoxes" j
-            WHERE j."householdId" = ${partnerHouseholdId18}
+            WHERE j."pantryVisitDateTime" >= ${range.start}
+              AND j."pantryVisitDateTime" <= ${range.end}
+              AND LOWER(TRIM(j."householdName")) = LOWER(TRIM(${orgNameOnly}))
+        `;
+        return rows[0] ?? { justEatsPoundsDelivered: 0, justEatsTotalDeliveries: 0 };
+    }
+
+    const hh = scopeEffectiveHouseholdId18(scope);
+    if (hh) {
+        const rows = await prisma.$queryRaw<JustEatsStatsRow[]>`
+            SELECT
+                (COALESCE(SUM(COALESCE(j."numberDistributed", 1)), 0) * 25)::float AS "justEatsPoundsDelivered",
+                COUNT(*)::int AS "justEatsTotalDeliveries"
+            FROM "JustEatsBoxes" j
+            WHERE j."householdId" = ${hh}
               AND j."pantryVisitDateTime" >= ${range.start}
               AND j."pantryVisitDateTime" <= ${range.end}
         `;
         return rows[0] ?? { justEatsPoundsDelivered: 0, justEatsTotalDeliveries: 0 };
     }
+
     const rows = await prisma.$queryRaw<JustEatsStatsRow[]>`
         SELECT
             (COALESCE(SUM(COALESCE(j."numberDistributed", 1)), 0) * 25)::float AS "justEatsPoundsDelivered",
@@ -123,7 +264,7 @@ async function queryJustEatsStats(
 
 /**
  * GET /api/overview/stats?start=...&end=...&destination=...
- * Bulk & rescue totals from AllProductPackageDestinations + AllPackagesByItem (zero-pound delivery days/buckets excluded).
+ * Bulk & rescue: joined destination pipeline plus orphan distribution-only inventory rows (no double count).
  * Just Eats from JustEatsBoxes (25 lb/box).
  */
 export async function GET(request: NextRequest) {
@@ -137,11 +278,10 @@ export async function GET(request: NextRequest) {
         if (scopeErr) return scopeErr;
 
         const range = parseDateRange(searchParams) ?? getDefaultRange();
-        const partnerHouseholdId18 = scopeToPartnerHouseholdId18(scope);
 
         const [bulkRescue, justEats] = await Promise.all([
-            queryBulkAndRescueStats(range, partnerHouseholdId18),
-            queryJustEatsStats(range, partnerHouseholdId18),
+            queryBulkAndRescueStats(range, scope),
+            queryJustEatsStats(range, scope),
         ]);
 
         return NextResponse.json({

--- a/src/components/ui/AddPartnerModal.tsx
+++ b/src/components/ui/AddPartnerModal.tsx
@@ -11,7 +11,7 @@ interface AddPartnerModalProps {
         membersCount: number;
     }[];
     onClose: () => void;
-    onSubmit: (data: { name: string; householdId18: string }) => Promise<void>;
+    onSubmit: (data: { name: string; householdId18?: string }) => Promise<void>;
     onDelete: (organizationId: string) => Promise<void>;
 }
 
@@ -55,16 +55,11 @@ export function AddPartnerModal({
             setError('Organization name is required');
             return;
         }
-        if (!householdId18.trim()) {
-            setError('Household ID 18 is required');
-            return;
-        }
-
         try {
             setIsSubmitting(true);
             await onSubmit({
                 name: name.trim(),
-                householdId18: householdId18.trim(),
+                ...(householdId18.trim() ? { householdId18: householdId18.trim() } : {}),
             });
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to create organization');
@@ -171,7 +166,7 @@ export function AddPartnerModal({
                                     htmlFor="householdId18"
                                     className="flex items-center gap-1.5 text-xs font-medium text-gray-700 mb-1.5 uppercase tracking-wide"
                                 >
-                                    Salesforce ID <span className="text-red-500">*</span>
+                                    Salesforce household ID (optional)
                                     <span className="relative inline-flex group">
                                         <button
                                             type="button"

--- a/src/components/ui/DeliverySummary.tsx
+++ b/src/components/ui/DeliverySummary.tsx
@@ -49,6 +49,7 @@ const DeliverySummary: React.FC<DeliverySummaryProps> = ({
         const dateStr = new Date(delivery.date).toISOString().slice(0, 10);
         const params = new URLSearchParams({ date: dateStr, org });
         if (delivery.householdId18) params.set('householdId18', delivery.householdId18);
+        else params.set('destination', org);
         try {
             const res = await fetch(`/api/overview/deliveries/detail?${params.toString()}`);
             if (!res.ok) return;

--- a/src/components/ui/PartnerCard.tsx
+++ b/src/components/ui/PartnerCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 
 export type PartnerCardProps = {
-    id: number;
+    id: number | string;
     name: string;
     householdId18?: string | null;
     location: string;

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -4,7 +4,7 @@ import { Search, ChevronRight } from 'lucide-react';
 import PartnerCard from './PartnerCard';
 
 type PartnerCardType = {
-    id: number;
+    id: number | string;
     name: string;
     location: string;
     type: string;

--- a/src/types/partner.ts
+++ b/src/types/partner.ts
@@ -1,5 +1,6 @@
 export type PartnerOrgCard = {
-    id: number;
+    /** Stable list key: `p-{householdId18}` or `d-{normalized name}`. */
+    id: string;
     name: string;
     householdId18?: string | null;
     location: string;


### PR DESCRIPTION
Admin search – The organization list now includes both saved partners and any other delivery destinations that show up in the data, without listing the same place twice.

Extra delivery lines from inventory – Some food only appears on the main inventory export (not in the package/destination tables). Those distribution lines are counted too, and we don’t count the same pounds twice when they already show up on the normal path.

Filtering – Overview and distribution numbers can be limited either by Salesforce household id (when you have it) or by organization name when that’s how the data is tied.

New partners without Salesforce id – Household id is optional when you create a partner. If you skip it, the system still creates an internal id so the account works.

Bug fixes – Fixed the “all organizations” totals query and the food-type charts so they don’t error in the database.

URLs – Picking or clearing an organization updates the address bar (replace, not a pile of history entries) so links and refresh behave predictably.

Just Eats without Salesforce id – Just Eats is matched using the destination name on the Just Eats side lining up with the partner organization name, not the fake internal id.