### PR TITLE
fix(overview,distribution): destinations, orphan data, and food types

### DIFF
--- a/lib/chartCompositionColors.ts
+++ b/lib/chartCompositionColors.ts
@@ -1,3 +1,5 @@
+import { inferFoodTypeLabelFromProductName } from '~/lib/inferredFoodType';
+
 /**
  * Colors for overview “Food Types Donated” and “Processing Breakdown” donuts.
  * Keep in sync with usage in `/api/overview/food-types` and distribution tag chips.
@@ -12,6 +14,7 @@ export const FOOD_TYPE_DONUT_COLORS = [
 ] as const;
 
 const FOOD_TYPE_FIXED_COLOR_BY_LABEL: Record<string, string> = {
+    bakery: '#D4A574',
     produce: '#B7D7BD',
     vegetables: '#B7D7BD',
     fruit: '#B7D7BD',
@@ -25,6 +28,8 @@ const FOOD_TYPE_FIXED_COLOR_BY_LABEL: Record<string, string> = {
     'dry goods': '#E7A54E',
     prepared: '#F4A6B8',
     other: '#B39DDB',
+    'non-food': '#94A3B8',
+    'non food': '#94A3B8',
 };
 
 /** Theme colors for overview processing donut. */
@@ -95,16 +100,25 @@ export function foodTypeColorLookupFromComposition(
     return m;
 }
 
-/** Same default label as food-types API when `productType` is null. */
-export function foodTypeLabelForRow(productType: string | null | undefined): string {
-    return productType?.trim() || 'Other';
+/**
+ * Display label for food type: uses `productType` when set, otherwise infers from
+ * pantry / line item name when it matches a known category (see `inferredFoodType`).
+ */
+export function foodTypeLabelForRow(
+    productType: string | null | undefined,
+    productName?: string | null | undefined
+): string {
+    const explicit = productType?.trim();
+    if (explicit) return explicit;
+    return inferFoodTypeLabelFromProductName(productName) ?? 'Other';
 }
 
 export function resolveFoodTypeDonutHex(
     productType: string | null | undefined,
-    lookup: Map<string, string>
+    lookup: Map<string, string>,
+    productName?: string | null | undefined
 ): string {
-    const label = foodTypeLabelForRow(productType);
+    const label = foodTypeLabelForRow(productType, productName);
     return lookup.get(label.toLowerCase()) ?? foodTypeFixedHex(label);
 }
 

--- a/lib/distributionDeliveries.ts
+++ b/lib/distributionDeliveries.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import type { PrismaClient } from '@prisma/client';
 import type { OverviewScope } from '~/lib/overviewAccess';
 import {
+    bulkJoinedResolvedOrgNameSql,
     destinationStatusIncludedCondition,
     distributionInventoryTypeCondition,
     inventoryTxPoundsSql,
@@ -86,7 +87,7 @@ export async function queryDistributionDeliveries(
                   `
                 : Prisma.sql` AND d."householdId18" = ${params.partnerHouseholdId18} `
             : params.orgFilter
-              ? Prisma.sql` AND ${orgNamesEqualSql(Prisma.sql`d."householdName"`, Prisma.sql`${params.orgFilter.trim()}`)} `
+              ? Prisma.sql` AND ${orgNamesEqualSql(bulkJoinedResolvedOrgNameSql(), Prisma.sql`${params.orgFilter.trim()}`)} `
               : Prisma.empty;
 
     const orphanSearchClause = search
@@ -103,10 +104,7 @@ export async function queryDistributionDeliveries(
         SELECT * FROM (
             SELECT
                 d."date" AS "date",
-                COALESCE(
-                    NULLIF(BTRIM(pt."organizationName"), ''),
-                    NULLIF(BTRIM(d."householdName"), '')
-                ) AS "organizationName",
+                ${bulkJoinedResolvedOrgNameSql()} AS "organizationName",
                 d."householdId18" AS "householdId18",
                 p."pantryProductName" AS "productName",
                 COALESCE(p."distributionAmount", 1) AS "distributionAmount",
@@ -189,7 +187,10 @@ export async function queryJustEatsDistributionDeliveries(
         params.partnerHouseholdId18 != null && params.partnerHouseholdId18 !== ''
             ? Prisma.sql` AND j."householdId" = ${params.partnerHouseholdId18} `
             : params.orgFilter
-              ? Prisma.sql` AND ${orgNamesEqualSql(Prisma.sql`j."householdName"`, Prisma.sql`${params.orgFilter.trim()}`)} `
+              ? Prisma.sql` AND ${orgNamesEqualSql(
+                    Prisma.sql`COALESCE(NULLIF(BTRIM(pt."organizationName"), ''), NULLIF(BTRIM(j."householdName"), ''))`,
+                    Prisma.sql`${params.orgFilter.trim()}`
+                )} `
               : Prisma.empty;
 
     // Match overview/stats `orgNameOnly` + household-id scope: no EXISTS guard.
@@ -213,6 +214,12 @@ export async function queryJustEatsDistributionDeliveries(
                   FROM "AllInventoryTransactions" t2
                   WHERE TRIM(COALESCE(t2."destination", '')) <> ''
                     AND LOWER(TRIM(COALESCE(t2."inventoryType", ''))) = 'distribution'
+
+                  UNION
+
+                  SELECT LOWER(TRIM(p2."organizationName")) AS org_name
+                  FROM "Partner" p2
+                  WHERE TRIM(COALESCE(p2."organizationName", '')) <> ''
               ) valid_orgs
               WHERE valid_orgs.org_name = LOWER(TRIM(j."householdName"))
           )

--- a/lib/inferredFoodType.ts
+++ b/lib/inferredFoodType.ts
@@ -1,0 +1,91 @@
+/**
+ * When `AllInventoryTransactions.productType` is missing, many rows still use a
+ * pantry / package name that is itself a standard food category (e.g. "Bakery").
+ * Align with `scripts/import-newdata-to-neon.js` KNOWN_PRODUCT_TYPES.
+ */
+const PANTRY_NAME_TO_LABEL = new Map<string, string>([
+    ['bakery', 'Bakery'],
+    ['produce', 'Produce'],
+    ['vegetables', 'Vegetables'],
+    ['fruit', 'Fruit'],
+    ['protein', 'Protein'],
+    ['dairy', 'Dairy'],
+    ['dry', 'Dry Goods'],
+    ['grain', 'Grain'],
+    ['grains', 'Grains'],
+    ['dry goods', 'Dry Goods'],
+    ['non-food', 'Non-Food'],
+    ['non food', 'Non-Food'],
+    ['prepared', 'Prepared'],
+    ['other', 'Other'],
+    ['misc cold', 'Misc. Cold'],
+    ['misc. cold', 'Misc. Cold'],
+    ['frozen meat', 'Frozen Meat'],
+]);
+
+function normalizePantryLookupKey(name: string): string {
+    return name.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/** @returns Canonical food-type label, or null if the name is not a known category. */
+export function inferFoodTypeLabelFromProductName(
+    pantryProductName: string | null | undefined
+): string | null {
+    if (pantryProductName == null) return null;
+    const key = normalizePantryLookupKey(pantryProductName);
+    if (!key) return null;
+    return PANTRY_NAME_TO_LABEL.get(key) ?? null;
+}
+
+/**
+ * Effective food type for inventory row `t` joined to package `p`.
+ * Keep WHEN list in sync with PANTRY_NAME_TO_LABEL.
+ */
+export const EFFECTIVE_PRODUCT_TYPE_SQL_JOINED = `COALESCE(
+    NULLIF(TRIM(t."productType"), ''),
+    CASE LOWER(TRIM(COALESCE(NULLIF(TRIM(p."pantryProductName"), ''), NULLIF(TRIM(t."pantryProductName"), ''))))
+        WHEN 'bakery' THEN 'Bakery'
+        WHEN 'produce' THEN 'Produce'
+        WHEN 'vegetables' THEN 'Vegetables'
+        WHEN 'fruit' THEN 'Fruit'
+        WHEN 'protein' THEN 'Protein'
+        WHEN 'dairy' THEN 'Dairy'
+        WHEN 'dry' THEN 'Dry Goods'
+        WHEN 'grain' THEN 'Grain'
+        WHEN 'grains' THEN 'Grains'
+        WHEN 'dry goods' THEN 'Dry Goods'
+        WHEN 'non-food' THEN 'Non-Food'
+        WHEN 'non food' THEN 'Non-Food'
+        WHEN 'prepared' THEN 'Prepared'
+        WHEN 'other' THEN 'Other'
+        WHEN 'misc cold' THEN 'Misc. Cold'
+        WHEN 'misc. cold' THEN 'Misc. Cold'
+        WHEN 'frozen meat' THEN 'Frozen Meat'
+        ELSE NULL
+    END
+)`;
+
+/** Orphan distribution row: only `t` is in scope (no package alias `p`). */
+export const EFFECTIVE_PRODUCT_TYPE_SQL_ORPHAN = `COALESCE(
+    NULLIF(TRIM(t."productType"), ''),
+    CASE LOWER(TRIM(COALESCE(t."pantryProductName", '')))
+        WHEN 'bakery' THEN 'Bakery'
+        WHEN 'produce' THEN 'Produce'
+        WHEN 'vegetables' THEN 'Vegetables'
+        WHEN 'fruit' THEN 'Fruit'
+        WHEN 'protein' THEN 'Protein'
+        WHEN 'dairy' THEN 'Dairy'
+        WHEN 'dry' THEN 'Dry Goods'
+        WHEN 'grain' THEN 'Grain'
+        WHEN 'grains' THEN 'Grains'
+        WHEN 'dry goods' THEN 'Dry Goods'
+        WHEN 'non-food' THEN 'Non-Food'
+        WHEN 'non food' THEN 'Non-Food'
+        WHEN 'prepared' THEN 'Prepared'
+        WHEN 'other' THEN 'Other'
+        WHEN 'misc cold' THEN 'Misc. Cold'
+        WHEN 'misc. cold' THEN 'Misc. Cold'
+        WHEN 'frozen meat' THEN 'Frozen Meat'
+        ELSE NULL
+    END
+)`;

--- a/lib/inventoryDistributionSql.ts
+++ b/lib/inventoryDistributionSql.ts
@@ -50,3 +50,14 @@ export function normalizedOrgNameSql(value: Prisma.Sql): Prisma.Sql {
 export function orgNamesEqualSql(left: Prisma.Sql, right: Prisma.Sql): Prisma.Sql {
     return Prisma.sql`${normalizedOrgNameSql(left)} = ${normalizedOrgNameSql(right)}`;
 }
+
+/**
+ * Resolved org label for a joined bulk row: inventory destination, then Partner, then destination household name.
+ */
+export function bulkJoinedResolvedOrgNameSql(): Prisma.Sql {
+    return Prisma.sql`COALESCE(
+        NULLIF(TRIM(t."destination"), ''),
+        NULLIF(BTRIM(pt."organizationName"), ''),
+        NULLIF(BTRIM(d."householdName"), '')
+    )`;
+}

--- a/lib/overviewAccess.ts
+++ b/lib/overviewAccess.ts
@@ -125,6 +125,28 @@ export function scopeToPartnerHouseholdId18(scope: OverviewScope): string | unde
 }
 
 /**
+ * Name used to match orphan `AllInventoryTransactions.destination` when the request is scoped
+ * by Salesforce household id. Uses `scope.destination` first, then `Partner.organizationName`.
+ */
+export async function scopeOrphanDestinationMatchName(scope: OverviewScope): Promise<string> {
+    if (scope.kind === 'partner') {
+        return scope.destination?.trim() ?? '';
+    }
+    if (scope.kind === 'admin') {
+        const d = scope.destination?.trim() ?? '';
+        if (d.length > 0) return d;
+        const hh = scope.destinationHouseholdId18?.trim();
+        if (!hh || hh.startsWith(PENDING_PARTNER_HOUSEHOLD_PREFIX)) return '';
+        const partner = await prisma.partner.findFirst({
+            where: { householdId18: hh },
+            select: { organizationName: true },
+        });
+        return partner?.organizationName?.trim() ?? '';
+    }
+    return '';
+}
+
+/**
  * When true, bulk/rescue metrics come from destination/org name (inventory `destination`,
  * destination tables’ household names), not Salesforce household id joins.
  */

--- a/src/app/(dashboard)/distribution/page.tsx
+++ b/src/app/(dashboard)/distribution/page.tsx
@@ -400,7 +400,7 @@ function DistributionContent() {
         const byKey = new Map<string, string>();
         for (const label of availableProductTypes) byKey.set(label.toLowerCase(), label);
         for (const row of data) {
-            const label = foodTypeLabelForRow(row.productType).trim();
+            const label = foodTypeLabelForRow(row.productType, row.productName).trim();
             byKey.set(label.toLowerCase(), label);
         }
         return [...byKey.values()].sort((a, b) =>
@@ -415,7 +415,9 @@ function DistributionContent() {
         const filtered = data.filter(row => {
             const prog = rowProgram(row);
             if (filterPrograms.length > 0 && !filterPrograms.includes(prog)) return false;
-            const ptKey = foodTypeLabelForRow(row.productType).trim().toLowerCase();
+            const ptKey = foodTypeLabelForRow(row.productType, row.productName)
+                .trim()
+                .toLowerCase();
             if (filterProductTypes.length > 0 && !selectedProductTypeKeys.has(ptKey)) return false;
             const pk = processingKey(row.minimallyProcessedFood);
             if (filterProcessing.length > 0 && !filterProcessing.includes(pk)) return false;
@@ -540,7 +542,7 @@ function DistributionContent() {
                 ? ''
                 : Number(d.unitWeightLbs),
             Number(d.weightLbs ?? 0),
-            foodTypeLabelForRow(d.productType),
+            foodTypeLabelForRow(d.productType, d.productName),
             processingDisplayLabel(d.minimallyProcessedFood),
             programExportLabel(d),
         ]);
@@ -1280,7 +1282,10 @@ function DistributionContent() {
                                     ) : filteredData.length > 0 ? (
                                         paginatedData.map((d, index) => {
                                             const isJustEats = rowProgram(d) === 'just_eats';
-                                            const typeLabel = foodTypeLabelForRow(d.productType);
+                                            const typeLabel = foodTypeLabelForRow(
+                                                d.productType,
+                                                d.productName
+                                            );
                                             const procLabel = processingDisplayLabel(
                                                 d.minimallyProcessedFood
                                             );
@@ -1357,7 +1362,8 @@ function DistributionContent() {
                                                                         style={chipStyleFromDonutHex(
                                                                             resolveFoodTypeDonutHex(
                                                                                 d.productType,
-                                                                                foodTypeColorLookup
+                                                                                foodTypeColorLookup,
+                                                                                d.productName
                                                                             )
                                                                         )}
                                                                     >

--- a/src/app/api/distribution/deliveries/route.ts
+++ b/src/app/api/distribution/deliveries/route.ts
@@ -1,23 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '~/lib/prisma';
-import type { OverviewScope } from '~/lib/overviewAccess';
 import {
     getOverviewScope,
     overviewScopeErrorResponse,
     scopeEffectiveHouseholdId18,
+    scopeOrphanDestinationMatchName,
 } from '~/lib/overviewAccess';
 import {
     distributionOrgScopeFromOverview,
     queryDistributionDeliveries,
     queryJustEatsDistributionDeliveries,
 } from '~/lib/distributionDeliveries';
-
-function destinationLabel(scope: OverviewScope): string | undefined {
-    if (scope.kind === 'partner' || scope.kind === 'admin') {
-        return scope.destination?.trim();
-    }
-    return undefined;
-}
 
 /**
  * GET /api/distribution/deliveries?start=&end=&search=&destination=
@@ -47,7 +40,10 @@ export async function GET(req: NextRequest) {
     const search = (searchParams.get('search') || '').trim().toLowerCase();
     const partnerHouseholdId18 = scopeEffectiveHouseholdId18(scope);
     const orgFilter = partnerHouseholdId18 ? undefined : distributionOrgScopeFromOverview(scope);
-    const destForOrphan = partnerHouseholdId18 ? destinationLabel(scope) : undefined;
+    const destForOrphan =
+        partnerHouseholdId18 != null && partnerHouseholdId18 !== ''
+            ? (await scopeOrphanDestinationMatchName(scope)) || undefined
+            : undefined;
 
     const [bulk, justEats] = await Promise.all([
         queryDistributionDeliveries(prisma, {

--- a/src/app/api/distribution/filter-options/route.ts
+++ b/src/app/api/distribution/filter-options/route.ts
@@ -6,7 +6,9 @@ import {
     overviewScopeErrorResponse,
     scopeEffectiveHouseholdId18,
     scopeOrganizationNameFilter,
+    scopeOrphanDestinationMatchName,
 } from '~/lib/overviewAccess';
+import { bulkJoinedResolvedOrgNameSql } from '~/lib/inventoryDistributionSql';
 import { foodTypeLabelForRow } from '~/lib/chartCompositionColors';
 import {
     distributionInventoryTypeCondition,
@@ -14,7 +16,7 @@ import {
     orphanInventoryCondition,
 } from '~/lib/inventoryDistributionSql';
 
-type ProductTypeRow = { productType: string | null };
+type ProductTypeRow = { productType: string | null; pantryProductName: string | null };
 
 /**
  * GET /api/distribution/filter-options
@@ -32,10 +34,7 @@ export async function GET(req: NextRequest) {
 
         const hh = scopeEffectiveHouseholdId18(scope);
         const orgNameOnly = scopeOrganizationNameFilter(scope);
-        const destLabel =
-            scope.kind === 'partner' || scope.kind === 'admin'
-                ? (scope.destination?.trim() ?? '')
-                : '';
+        const destLabel = await scopeOrphanDestinationMatchName(scope);
 
         const joinedClause = hh
             ? destLabel.length > 0
@@ -50,7 +49,9 @@ export async function GET(req: NextRequest) {
                   `
                 : Prisma.sql`WHERE d."householdId18" = ${hh}`
             : orgNameOnly
-              ? Prisma.sql`WHERE ${orgNamesEqualSql(Prisma.sql`COALESCE(pt."organizationName", d."householdName")`, Prisma.sql`${orgNameOnly}`)}`
+              ? Prisma.sql`WHERE (
+                    ${orgNamesEqualSql(bulkJoinedResolvedOrgNameSql(), Prisma.sql`${orgNameOnly}`)}
+                  )`
               : Prisma.sql``;
 
         const orphanClause =
@@ -63,9 +64,11 @@ export async function GET(req: NextRequest) {
                     : Prisma.sql``;
 
         const rows = await prisma.$queryRaw<ProductTypeRow[]>`
-            SELECT DISTINCT t."productType" AS "productType"
+            SELECT DISTINCT t."productType" AS "productType", t."pantryProductName" AS "pantryProductName"
             FROM (
-                SELECT t."productType"
+                SELECT
+                    t."productType",
+                    COALESCE(NULLIF(TRIM(p."pantryProductName"), ''), NULLIF(TRIM(t."pantryProductName"), '')) AS "pantryProductName"
                 FROM "AllInventoryTransactions" t
                 INNER JOIN "AllPackagesByItem" p
                     ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
@@ -76,7 +79,7 @@ export async function GET(req: NextRequest) {
 
                 UNION
 
-                SELECT t."productType"
+                SELECT t."productType", NULLIF(TRIM(t."pantryProductName"), '') AS "pantryProductName"
                 FROM "AllInventoryTransactions" t
                 WHERE ${distributionInventoryTypeCondition}
                   AND ${orphanInventoryCondition}
@@ -86,7 +89,7 @@ export async function GET(req: NextRequest) {
 
         const unique = new Set<string>();
         for (const row of rows) {
-            unique.add(foodTypeLabelForRow(row.productType).trim());
+            unique.add(foodTypeLabelForRow(row.productType, row.pantryProductName).trim());
         }
 
         return NextResponse.json({

--- a/src/app/api/overview/deliveries/detail/route.ts
+++ b/src/app/api/overview/deliveries/detail/route.ts
@@ -14,18 +14,25 @@ import {
     orgNamesEqualSql,
     orphanInventoryCondition,
 } from '~/lib/inventoryDistributionSql';
+import { inferFoodTypeLabelFromProductName } from '~/lib/inferredFoodType';
 
 type FoodRow = { productName: string | null; totalWeightLbs: number | null };
 
-type TagRow = { productType: string | null; minimallyProcessedFood: boolean | null };
+type TagRow = {
+    productType: string | null;
+    minimallyProcessedFood: boolean | null;
+    pantryProductName: string | null;
+};
 
 function buildNutritionalTags(rows: TagRow[]): string[] {
     const types = new Set<string>();
     let anyTrue = false;
     let anyFalse = false;
     for (const r of rows) {
-        const pt = r.productType?.trim();
-        if (pt) types.add(pt);
+        const explicit = r.productType?.trim();
+        const inferred = inferFoodTypeLabelFromProductName(r.pantryProductName);
+        if (explicit) types.add(explicit);
+        else if (inferred) types.add(inferred);
         if (r.minimallyProcessedFood === true) anyTrue = true;
         if (r.minimallyProcessedFood === false) anyFalse = true;
     }
@@ -179,7 +186,10 @@ export async function GET(request: NextRequest) {
                 GROUP BY t."productPackageName"
             `,
             prisma.$queryRaw<TagRow[]>`
-                SELECT DISTINCT t."productType", t."minimallyProcessedFood"
+                SELECT DISTINCT
+                    t."productType",
+                    t."minimallyProcessedFood",
+                    COALESCE(NULLIF(TRIM(p."pantryProductName"), ''), NULLIF(TRIM(t."pantryProductName"), '')) AS "pantryProductName"
                 FROM "AllInventoryTransactions" t
                 INNER JOIN "AllPackagesByItem" p ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
                 INNER JOIN "AllProductPackageDestinations" d ON d."productPackageId18" = p."productPackageId18"
@@ -189,7 +199,10 @@ export async function GET(request: NextRequest) {
                   AND ${joinedPartnerPredicate}
             `,
             prisma.$queryRaw<TagRow[]>`
-                SELECT DISTINCT t."productType", t."minimallyProcessedFood"
+                SELECT DISTINCT
+                    t."productType",
+                    t."minimallyProcessedFood",
+                    NULLIF(TRIM(t."pantryProductName"), '') AS "pantryProductName"
                 FROM "AllInventoryTransactions" t
                 WHERE DATE_TRUNC('day', t."date") = DATE_TRUNC('day', ${date})
                   AND ${distributionInventoryTypeCondition}

--- a/src/app/api/overview/deliveries/route.ts
+++ b/src/app/api/overview/deliveries/route.ts
@@ -8,6 +8,7 @@ import {
     overviewScopeErrorResponse,
     scopeEffectiveHouseholdId18,
     scopeOrganizationNameFilter,
+    scopeOrphanDestinationMatchName,
 } from '~/lib/overviewAccess';
 import {
     destinationStatusIncludedCondition,
@@ -48,13 +49,6 @@ function getDefaultRange(): { start: Date; end: Date } {
     const start = new Date(end);
     start.setDate(start.getDate() - 29);
     return { start, end };
-}
-
-function destinationLabel(scope: OverviewScope): string {
-    if (scope.kind === 'partner' || scope.kind === 'admin') {
-        return scope.destination?.trim() ?? '';
-    }
-    return '';
 }
 
 type DeliveryOut = {
@@ -224,7 +218,7 @@ export async function GET(request: NextRequest) {
         }
 
         if (hh) {
-            const destLabel = destinationLabel(scope);
+            const destLabel = await scopeOrphanDestinationMatchName(scope);
             const joinedScopedPredicate =
                 destLabel.length > 0
                     ? Prisma.sql`

--- a/src/app/api/overview/food-types/route.ts
+++ b/src/app/api/overview/food-types/route.ts
@@ -7,6 +7,7 @@ import {
     overviewScopeErrorResponse,
     scopeEffectiveHouseholdId18,
     scopeOrganizationNameFilter,
+    scopeOrphanDestinationMatchName,
 } from '~/lib/overviewAccess';
 import {
     COMPOSITION_EMPTY_SEGMENT_COLOR,
@@ -14,6 +15,10 @@ import {
     foodTypeFixedHex,
     type FoodTypeCompositionEntry,
 } from '~/lib/chartCompositionColors';
+import {
+    EFFECTIVE_PRODUCT_TYPE_SQL_JOINED,
+    EFFECTIVE_PRODUCT_TYPE_SQL_ORPHAN,
+} from '~/lib/inferredFoodType';
 import {
     destinationStatusIncludedCondition,
     distributionInventoryTypeCondition,
@@ -54,13 +59,6 @@ function getDefaultRange(): { start: Date; end: Date } {
     return { start, end };
 }
 
-function destinationLabel(scope: OverviewScope): string {
-    if (scope.kind === 'partner' || scope.kind === 'admin') {
-        return scope.destination?.trim() ?? '';
-    }
-    return '';
-}
-
 /**
  * GET /api/overview/food-types?start=...&end=...&destination=...
  * Composition for bulk & recovery includes orphan distribution-only inventory rows.
@@ -78,7 +76,7 @@ export async function GET(request: NextRequest) {
         const range = parseDateRange(searchParams) ?? getDefaultRange();
         const partnerHouseholdId18 = scopeEffectiveHouseholdId18(scope);
         const orgNameOnly = scopeOrganizationNameFilter(scope);
-        const destLabel = destinationLabel(scope);
+        const destLabel = await scopeOrphanDestinationMatchName(scope);
 
         const joinedPartnerClause = partnerHouseholdId18
             ? destLabel.length > 0
@@ -111,7 +109,7 @@ export async function GET(request: NextRequest) {
         const foodTypeGrouped = await prisma.$queryRaw<ProductTypeRow[]>`
             SELECT "productType", SUM("pounds") AS "pounds" FROM (
                 SELECT
-                    t."productType" AS "productType",
+                    ${Prisma.raw(EFFECTIVE_PRODUCT_TYPE_SQL_JOINED)} AS "productType",
                     SUM(COALESCE(p."pantryProductWeightLbs", 0) * COALESCE(p."distributionAmount", 1)) AS "pounds"
                 FROM "AllInventoryTransactions" t
                 INNER JOIN "AllPackagesByItem" p
@@ -124,12 +122,12 @@ export async function GET(request: NextRequest) {
                   AND ${destinationStatusIncludedCondition}
                   ${joinedPartnerClause}
                   ${joinedNameClause}
-                GROUP BY t."productType"
+                GROUP BY ${Prisma.raw(EFFECTIVE_PRODUCT_TYPE_SQL_JOINED)}
 
                 UNION ALL
 
                 SELECT
-                    t."productType" AS "productType",
+                    ${Prisma.raw(EFFECTIVE_PRODUCT_TYPE_SQL_ORPHAN)} AS "productType",
                     SUM(${inventoryTxPoundsSql()}) AS "pounds"
                 FROM "AllInventoryTransactions" t
                 WHERE t."date" >= ${range.start}
@@ -137,7 +135,7 @@ export async function GET(request: NextRequest) {
                   AND ${distributionInventoryTypeCondition}
                   AND ${orphanInventoryCondition}
                   ${orphanScopeClause}
-                GROUP BY t."productType"
+                GROUP BY ${Prisma.raw(EFFECTIVE_PRODUCT_TYPE_SQL_ORPHAN)}
             ) sub
             GROUP BY "productType"
         `;

--- a/src/app/api/overview/partners/route.ts
+++ b/src/app/api/overview/partners/route.ts
@@ -76,7 +76,7 @@ export async function GET() {
                 orderBy: { organizationName: 'asc' },
             }),
             prisma.$queryRaw<{ name: string | null }[]>`
-                WITH valid_joined AS (
+                WITH                 valid_joined AS (
                     SELECT
                         TRIM(
                             COALESCE(
@@ -91,7 +91,13 @@ export async function GET() {
                         ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
                     INNER JOIN "AllProductPackageDestinations" d
                         ON d."productPackageId18" = p."productPackageId18"
-                    WHERE TRIM(COALESCE(d."householdName", '')) <> ''
+                    WHERE TRIM(
+                            COALESCE(
+                                NULLIF(TRIM(t."destination"), ''),
+                                NULLIF(TRIM(d."householdName"), ''),
+                                ''
+                            )
+                        ) <> ''
                       AND ${destinationStatusIncludedCondition}
                     GROUP BY TRIM(
                         COALESCE(
@@ -122,6 +128,12 @@ export async function GET() {
                     WHERE TRIM(COALESCE(j."householdName", '')) <> ''
                     GROUP BY TRIM(COALESCE(pt."organizationName", j."householdName"))
                     HAVING SUM(COALESCE(j."numberPickedUp", 1)) > 0
+                ),
+                package_destination_labels AS (
+                    SELECT DISTINCT TRIM(d."householdName") AS name
+                    FROM "AllProductPackageDestinations" d
+                    WHERE TRIM(COALESCE(d."householdName", '')) <> ''
+                      AND ${destinationStatusIncludedCondition}
                 )
                 SELECT DISTINCT TRIM(name) AS "name"
                 FROM (
@@ -130,6 +142,8 @@ export async function GET() {
                     SELECT name FROM valid_orphan
                     UNION
                     SELECT name FROM valid_just_eats
+                    UNION
+                    SELECT name FROM package_destination_labels
                 ) v
                 WHERE TRIM(COALESCE(name, '')) <> ''
                 ORDER BY 1 ASC
@@ -151,8 +165,14 @@ export async function GET() {
                         ON p."productInventoryRecordId18" = t."productInventoryRecordId18"
                     INNER JOIN "AllProductPackageDestinations" d
                         ON d."productPackageId18" = p."productPackageId18"
-                    WHERE TRIM(COALESCE(d."householdName", '')) <> ''
-                      AND TRIM(COALESCE(d."householdId18", '')) <> ''
+                    WHERE TRIM(COALESCE(d."householdId18", '')) <> ''
+                      AND TRIM(
+                            COALESCE(
+                                NULLIF(TRIM(t."destination"), ''),
+                                NULLIF(TRIM(d."householdName"), ''),
+                                ''
+                            )
+                        ) <> ''
                       AND ${destinationStatusIncludedCondition}
                     GROUP BY
                         d."householdId18",
@@ -195,15 +215,11 @@ export async function GET() {
                 .map(partner => [partner.householdId18?.trim() ?? '', partner] as const)
                 .filter(([householdId18]) => householdId18.length > 0)
         );
-        const aliasNormalizedForKnownPartners = new Set<string>();
         const preferredNameByHouseholdId = new Map<string, string>();
         for (const row of observedHouseholdNames) {
             const householdId18 = row.householdId18?.trim();
             const name = row.name?.trim() ?? '';
             if (!householdId18 || !name || isLikelySalesforceId(name)) continue;
-            if (partnerByHouseholdId.has(householdId18)) {
-                aliasNormalizedForKnownPartners.add(normalizeDestinationName(name));
-            }
             if (!preferredNameByHouseholdId.has(householdId18)) {
                 preferredNameByHouseholdId.set(householdId18, name);
             }
@@ -212,7 +228,15 @@ export async function GET() {
         for (const partner of partnerRows) {
             const partnerName = partner.organizationName?.trim() ?? '';
             if (!partnerName || isLikelySalesforceId(partnerName)) continue;
-            aliasNormalizedForKnownPartners.add(normalizeDestinationName(partnerName));
+            const key = normalizeDestinationName(partnerName);
+            if (byNormalized.has(key)) continue;
+            byNormalized.set(key, {
+                id: `p-${partner.householdId18}`,
+                name: partnerName,
+                householdId18: partner.householdId18,
+                location: '',
+                type: 'Partner',
+            });
         }
 
         for (const row of observedHouseholdNames) {
@@ -243,7 +267,6 @@ export async function GET() {
             if (!name) continue;
             if (isLikelySalesforceId(name)) continue;
             const key = normalizeDestinationName(name);
-            if (aliasNormalizedForKnownPartners.has(key)) continue;
             if (byNormalized.has(key)) continue;
             byNormalized.set(key, {
                 id: `d-${key}`,

--- a/src/app/api/overview/pounds-by-month/route.ts
+++ b/src/app/api/overview/pounds-by-month/route.ts
@@ -7,6 +7,7 @@ import {
     overviewScopeErrorResponse,
     scopeEffectiveHouseholdId18,
     scopeOrganizationNameFilter,
+    scopeOrphanDestinationMatchName,
 } from '~/lib/overviewAccess';
 import {
     destinationStatusIncludedCondition,
@@ -64,13 +65,6 @@ function getDefaultRange(): { start: Date; end: Date } {
     return { start, end };
 }
 
-function destinationLabel(scope: OverviewScope): string {
-    if (scope.kind === 'partner' || scope.kind === 'admin') {
-        return scope.destination?.trim() ?? '';
-    }
-    return '';
-}
-
 type DailyRow = { day: string; pounds: number | null };
 
 async function fetchBulkDaily(
@@ -97,7 +91,7 @@ async function fetchBulkDaily(
     }
 
     const hh = scopeEffectiveHouseholdId18(scope);
-    const destLabel = destinationLabel(scope);
+    const destLabel = await scopeOrphanDestinationMatchName(scope);
     if (hh) {
         if (destLabel.length === 0) {
             return prisma.$queryRaw<DailyRow[]>`
@@ -176,7 +170,7 @@ async function fetchOrphanDaily(
     }
 
     const hh = scopeEffectiveHouseholdId18(scope);
-    const destLabel = destinationLabel(scope);
+    const destLabel = await scopeOrphanDestinationMatchName(scope);
     if (hh && destLabel.length > 0) {
         return prisma.$queryRaw<DailyRow[]>`
             SELECT

--- a/src/app/api/overview/stats/route.ts
+++ b/src/app/api/overview/stats/route.ts
@@ -7,6 +7,7 @@ import {
     overviewScopeErrorResponse,
     scopeEffectiveHouseholdId18,
     scopeOrganizationNameFilter,
+    scopeOrphanDestinationMatchName,
 } from '~/lib/overviewAccess';
 import {
     destinationStatusIncludedCondition,
@@ -57,13 +58,6 @@ type JustEatsStatsRow = {
     justEatsPoundsDelivered: number | null;
     justEatsTotalDeliveries: number;
 };
-
-function destinationLabel(scope: OverviewScope): string {
-    if (scope.kind === 'partner' || scope.kind === 'admin') {
-        return scope.destination?.trim() ?? '';
-    }
-    return '';
-}
 
 async function queryBulkAndRescueStats(
     range: { start: Date; end: Date },
@@ -120,7 +114,7 @@ async function queryBulkAndRescueStats(
     const hh = scopeEffectiveHouseholdId18(scope);
 
     if (hh) {
-        const destLabel = destinationLabel(scope);
+        const destLabel = await scopeOrphanDestinationMatchName(scope);
         const rows =
             destLabel.length > 0
                 ? await prisma.$queryRaw<BulkRescueStatsRow[]>`


### PR DESCRIPTION
Infer food type labels from pantry product names when productType is null so overview charts and distribution tags are not all Other. Add shared SQL and TS maps in lib/inferredFoodType.

Resolve orphan inventory scope via Partner.organizationName when household id is set but destination is missing (scopeOrphanDestinationMatchName) and use it across stats, food-types, pounds-by-month, deliveries, and distribution APIs.

Expand org directory and matching: pre-seed Partner rows, union package destination names, allow joined rows keyed by transaction destination, bulkJoinedResolvedOrgNameSql for filters and display, and align filter-options with the same rules.

Relax partner list and distribution queries so non-partners and inventory- only destinations surface consistently.